### PR TITLE
Accept arbitrary request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.5.0 (master)
 
+- [#28](https://github.com/anycable/anycable/issues/28) Support arbitrary headers. ([@palkan][])
+
+Previously we hardcoded only "Cookie" header. Now we add all passed headers by WebSocket server to request env. 
+
 - [#27](https://github.com/anycable/anycable/issues/27) Add `error_msg` to RPC responses. ([@palkan][])
 
 Now RPC responses has 3 statuses:

--- a/lib/anycable/rpc_handler.rb
+++ b/lib/anycable/rpc_handler.rb
@@ -88,16 +88,23 @@ module Anycable
         'PATH_INFO' => uri.path,
         'SERVER_PORT' => uri.port.to_s,
         'HTTP_HOST' => uri.host,
-        'HTTP_COOKIE' => request.headers['Cookie'],
         # Hack to avoid Missing rack.input error
         'rack.request.form_input' => '',
         'rack.input' => '',
         'rack.request.form_hash' => {}
-      }
+      }.merge(build_headers(request.headers))
     end
 
     def build_socket(**options)
       Anycable::Socket.new(**options)
+    end
+
+    def build_headers(headers)
+      headers.each_with_object({}) do |(k, v), obj|
+        k = k.upcase
+        k.tr!('-', '_')
+        obj["HTTP_#{k}"] = v
+      end
     end
 
     def logger

--- a/spec/integrations/connection_spec.rb
+++ b/spec/integrations/connection_spec.rb
@@ -37,4 +37,27 @@ describe "client connection" do
       expect(subject.transmissions.first).to eq JSON.dump('type' => 'welcome')
     end
   end
+
+  context "with arbitrary headers" do
+    let(:request) do
+      Anycable::ConnectionRequest.new(
+        headers: {
+          'cookie' => 'username=john;',
+          'x-api-token' => 'abc123',
+          'X-Forwarded-For' => '1.2.3.4'
+        },
+        path: 'http://example.io/cable'
+      )
+    end
+
+    it "responds with success, correct identifiers and 'welcome' message", :aggregate_failures do
+      expect(subject.status).to eq :SUCCESS
+      identifiers = JSON.parse(subject.identifiers)
+      expect(identifiers).to include(
+        'token' => 'abc123',
+        'remote_ip' => '1.2.3.4'
+      )
+      expect(subject.transmissions.first).to eq JSON.dump('type' => 'welcome')
+    end
+  end
 end

--- a/spec/support/test_factory.rb
+++ b/spec/support/test_factory.rb
@@ -12,10 +12,12 @@ module Anycable
         @subscriptions = subscriptions
       end
 
+      # rubocop:disable Metrics/AbcSize
       def handle_open
         @identifiers['current_user'] = request.cookies["username"]
         @identifiers['path'] = request.path
-        @identifiers['token'] = request.params['token']
+        @identifiers['token'] = request.params['token'] || request.get_header('HTTP_X_API_TOKEN')
+        @identifiers['remote_ip'] = request.ip
 
         if @identifiers['current_user']
           transmit(type: 'welcome')


### PR DESCRIPTION
Closes #14.

Previously we hardcoded only `Cookie` header.