### PR TITLE
HTTP healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [#48](https://github.com/anycable/anycable/pull/48) Add HTTP health server ([@DarthSim](https://github.com/DarthSim))
+
 ## 0.5.1 (2018-06-13)
 
 Minor fixes.

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -14,7 +14,8 @@ module Anycable
                 log_file: nil,
                 log_level: :info,
                 log_grpc: false,
-                debug: false # Shortcut to enable GRPC logging and debug level
+                debug: false, # Shortcut to enable GRPC logging and debug level
+                http_health_port: nil
 
     def initialize(*)
       super
@@ -22,6 +23,10 @@ module Anycable
       return unless debug
       self.log_level = :debug
       self.log_grpc = true
+    end
+
+    def http_health_port_provided?
+      !http_health_port.nil? && http_health_port != ""
     end
   end
 end

--- a/lib/anycable/health_server.rb
+++ b/lib/anycable/health_server.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'webrick'
+require 'anycable/server'
+
+module Anycable
+  # Server for HTTP healthchecks
+  module HealthServer
+    class << self
+      def start(port)
+        return if running?
+
+        @health_server ||= build_server(port)
+        Thread.new { @health_server.start }
+
+        Anycable.logger.info "HTTP health server is listening on #{port}"
+      end
+
+      def stop
+        return unless running?
+        @health_server.shutdown
+      end
+
+      def running?
+        @health_server&.status == :Running
+      end
+
+      private
+
+      SUCCESS_RESPONSE = [200, "Ready"].freeze
+      FAILURE_RESPONSE = [503, "Not Ready"].freeze
+
+      def build_server(port)
+        WEBrick::HTTPServer.new(
+          Port: port,
+          Logger: Anycable.logger,
+          AccessLog: []
+        ).tap do |server|
+          server.mount_proc '/health' do |_, res|
+            res.status, res.body = Anycable::Server.running? ? SUCCESS_RESPONSE : FAILURE_RESPONSE
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/anycable/server.rb
+++ b/lib/anycable/server.rb
@@ -2,6 +2,7 @@
 
 require 'grpc'
 require 'anycable/rpc_handler'
+require 'anycable/health_server'
 
 module Anycable
   # Wrapper over GRPC server
@@ -11,11 +12,9 @@ module Anycable
 
       def start
         log_grpc! if Anycable.config.log_grpc
-        @grpc_server ||= build_server
 
-        Anycable.logger.info "RPC server is listening on #{Anycable.config.rpc_host}"
-        Anycable.logger.info "Broadcasting Redis channel: #{Anycable.config.redis_channel}"
-        grpc_server.run_till_terminated
+        start_http_health_server
+        start_grpc_server
       end
 
       def stop
@@ -34,11 +33,26 @@ module Anycable
 
       private
 
+      def start_grpc_server
+        @grpc_server ||= build_server
+
+        Anycable.logger.info "RPC server is listening on #{Anycable.config.rpc_host}"
+        Anycable.logger.info "Broadcasting Redis channel: #{Anycable.config.redis_channel}"
+
+        grpc_server.run_till_terminated
+      end
+
       def build_server
         GRPC::RpcServer.new.tap do |server|
           server.add_http2_port(Anycable.config.rpc_host, :this_port_is_insecure)
           server.handle(Anycable::RPCHandler)
         end
+      end
+
+      def start_http_health_server
+        return unless Anycable.config.http_health_port_provided?
+        Anycable::HealthServer.start(Anycable.config.http_health_port)
+        at_exit { Anycable::HealthServer.stop }
       end
     end
   end

--- a/spec/anycable/health_server_spec.rb
+++ b/spec/anycable/health_server_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "bg_helper"
+require "net/http"
+
+describe "health server" do
+  context "when server is running" do
+    before { allow(Anycable::Server).to receive(:running?).and_return(true) }
+
+    it "responds with 200" do
+      res = Net::HTTP.get_response(URI("http://localhost:#{Anycable.config.http_health_port}/health"))
+      expect(res.code).to eq "200"
+    end
+  end
+
+  context "when server is not running" do
+    before { allow(Anycable::Server).to receive(:running?).and_return(false) }
+
+    it "responds with 200" do
+      res = Net::HTTP.get_response(URI("http://localhost:#{Anycable.config.http_health_port}/health"))
+      expect(res.code).to eq "503"
+    end
+  end
+end

--- a/spec/bg_helper.rb
+++ b/spec/bg_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-Thread.new { Anycable::Server.start }
+Thread.new do
+  Anycable.config.http_health_port = 54_321
+  Anycable::Server.start
+end
 
 at_exit do
   Anycable::Server.stop

--- a/spec/support/anycable.yml
+++ b/spec/support/anycable.yml
@@ -4,3 +4,4 @@ redis_sentinels:
   - { host: 'redis-1-1', port: 26379 }
   - { host: 'redis-1-2', port: 26379 }
   - { host: 'redis-1-3', port: 26379 }
+http_health_port: 54321

--- a/spec/support/test_logger.rb
+++ b/spec/support/test_logger.rb
@@ -19,5 +19,7 @@ class TestLogger
     define_method severity.downcase do |msg|
       @store[severity.downcase] << msg
     end
+
+    define_method("#{severity.downcase}?") { true }
   end
 end


### PR DESCRIPTION
When `health_port` config is provided (nil by default), `Anycable::Server.start` starts health check server on the provided port. The healthcheck server responds on `/health` with 200 when the gRPC server is running and with 503 when it isn'.

This can be used for readiness and liveness checks.