### PR TITLE
Add CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ## 0.6.0-dev
 
+#### CLI
+
+AnyCable now ships with a CLI–`anycable`.
+
+Use it to run a gRPC server:
+
+```sh
+# run anycable and load app from app.rb
+bundle exec anycable -r app.rb
+# or
+bundle exec anycable --require app.rb
+```
+
+All configuration options are also supported as CLI options (see `anycable -h` for more information).
+
+The only required options is the application file to load (`-r/--require`).
+
+You can omit it if you want to load an app form `./config/environment.rb` (e.g. with Rails) or `./config/anycable.rb`.
+
 #### Configuration
 
 - Default server host is changed from `localhost:50051` to `0.0.0.0:50051`
@@ -18,6 +37,12 @@ end
 ```
 - `REDIS_URL` env is used by default if present (and no `ANYCABLE_REDIS_URL` specified)
 - Make HTTP health check url configurable
+- Add ability to pass Redis Sentinel config as array of string.
+
+Now it's possible to pass Sentinel configuration via env vars:
+
+```sh
+ANYCABLE_REDIS_SENTINELS=127.0.0.1:26380,127.0.0.1:26381 bundle exec anycable
 ```
 
 ## 0.5.2 (2018-09-06)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitPitch](https://gitpitch.com/assets/badge.svg)](https://gitpitch.com/anycable/anycable/master?grs=github) [![Gem Version](https://badge.fury.io/rb/anycable.svg)](https://rubygems.org/gems/anycable) [![Build Status](https://travis-ci.org/anycable/anycable.svg?branch=master)](https://travis-ci.org/anycable/anycable)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/anycable/Lobby)
 
-# Anycable
+# AnyCable
 
 AnyCable allows you to use any WebSocket server (written in any language) as a replacement for your Ruby server (such as Faye, ActionCable, etc).
 
@@ -64,7 +64,7 @@ Read our [Wiki](https://github.com/anycable/anycable/wiki) for more.
 
 Anycable uses [anyway_config](https://github.com/palkan/anyway_config), thus it is also possible to set configuration variables through `secrets.yml` or environment vars.
 
-### Example with redis sentinel
+### Example with Redis Sentinel
 
 ```yaml
   rpc_host: "localhost:50123"
@@ -75,7 +75,7 @@ Anycable uses [anyway_config](https://github.com/palkan/anyway_config), thus it 
     - { host: 'redis-1-3', port: 26379 }
 ```
 
-## ActionCable Compatibility
+## Action Cable Compatibility
 
 This is the compatibility list for the AnyCable gem, not for AnyCable servers (which may not support some of the features yet).
 

--- a/anycable.gemspec
+++ b/anycable.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/anycable/anycable"
   spec.license       = "MIT"
 
+  spec.executables   = ["anycable"]
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 

--- a/anycable.gemspec
+++ b/anycable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "anyway_config", "~> 1.3"
+  spec.add_dependency "anyway_config", "~> 1.4.1"
   spec.add_dependency "grpc", "~> 1.15"
   spec.add_dependency "redis", "~> 4.0"
 

--- a/bin/anycable
+++ b/bin/anycable
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/anycable/cli"
+
+begin
+  cli = Anycable::CLI.new
+  cli.run(ARGV)
+rescue => e
+  raise e if $DEBUG
+  STDERR.puts e.message
+  STDERR.puts e.backtrace.join("\n")
+  exit 1
+end

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -212,6 +212,7 @@ module Anycable
             --rpc-host=host                   Local address to run gRPC server on, default: "[::]:50051"
             --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
             --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
+            --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
             --log-level=level                 Logging level, default: "info"
             --log-file=path                   Path to log file, default: <none> (log to STDOUT)
             --log-grpc                        Enable gRPC logging (disabled by default)

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
 require "optparse"
-require "pry-byebug"
 
 require "anycable"
 
+$stdout.sync = true
+
 module Anycable
   # Command-line interface for running AnyCable gRPC server
+  # rubocop:disable Metrics/ClassLength
   class CLI
+    # (not-so-big) List of common boot files for
+    # different applications
+    APP_CANDIDATES = %w[
+      ./config/environment.rb
+    ].freeze
+
     def run(args)
       unknown_opts = parse_cli_options!(args)
 
@@ -15,9 +23,11 @@ module Anycable
         Anycable.config.parse_options!(unknown_opts)
       rescue OptionParser::InvalidOption => e
         $stdout.puts e.message
-        # TODO: print usage
+        $stdout.puts "Run anycable -h to see available options"
         exit(1)
       end
+
+      boot_app!
 
       Anycable::Server.start
     end
@@ -25,6 +35,44 @@ module Anycable
     private
 
     attr_reader :boot_file
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def boot_app!
+      @boot_file ||= try_detect_app
+
+      if boot_file.nil?
+        Anycable.logger.fatal(
+          "Couldn't find an application to load. " \
+          "Please specify the explicit path via -r option, e.g:" \
+          " anycable -r ./config/boot.rb or anycable -r /app/config/load_me.rb"
+        )
+        exit(1)
+      end
+
+      Anycable.logger.info "Loading application from #{boot_file} ..."
+
+      begin
+        require boot_file
+      rescue LoadError => e
+        Anycable.logger.fatal(
+          "Failed to load application: #{e.message}. " \
+          "Please specify the explicit path via -r option, e.g:" \
+          " anycable -r ./config/boot.rb or anycable -r /app/config/load_me.rb"
+        )
+        exit(1)
+      end
+
+      if defined?(::Rails)
+        Anycable.logger.info "Rails application is loaded"
+      else
+        Anycable.logger.info "Application is loaded"
+      end
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def try_detect_app
+      APP_CANDIDATES.detect { |path| File.exist?(path) }
+    end
 
     # rubocop:disable Metrics/MethodLength
     def parse_cli_options!(args)
@@ -44,7 +92,6 @@ module Anycable
 
       unknown_opts
     end
-    # rubocop:enable Metrics/MethodLength
 
     def build_cli_parser
       OptionParser.new do |o|
@@ -56,7 +103,48 @@ module Anycable
         o.on "-r", "--require [PATH|DIR]", "Location of application file to require" do |arg|
           @boot_file = arg
         end
+
+        o.on_tail "-h", "--help", "Show help" do
+          $stdout.puts usage
+          exit(0)
+        end
       end
     end
+    # rubocop:enable Metrics/MethodLength
+
+    def usage
+      <<~HELP
+        anycable: run AnyCable gRPC server (https://anycable.io)
+
+        VERSION
+          anycable/#{Anycable::VERSION}
+
+        USAGE
+          $ anycable [options]
+
+        BASIC OPTIONS
+            -r, --require=path                Location of application file to require, default: "config/environment.rb"
+            --rpc-host=host                   Local address to run gRPC server on, default: "[::]:50051"
+            --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
+            --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
+            --log-level=level                 Logging level, default: "info"
+            --log-file=path                   Path to log file, default: <none> (log to STDOUT)
+            --log-grpc                        Enable gRPC logging (disabled by default)
+            --debug                           Turn on verbose logging ("debug" level and gRPC logging on)
+            -v, --version                     Print version and exit
+            -h, --help                        Show this help
+
+        HTTP HEALTH CHECKER OPTIONS
+            --http-health-port=port           Port to run HTTP health server on, default: <none> (disabled)
+            --http-health-path=path           Endpoint to server health cheks, default: "/health"
+
+        GRPC OPTIONS
+            --rpc-pool-size=size              gRPC workers pool size, default: 30
+            --rpc-max-waiting-requests=num    Max waiting requests queue size, default: 20
+            --rpc-poll-period=seconds         Poll period (sec), default: 1
+            --rpc-pool-keep-alive=seconds     Keep-alive polling interval (sec), default: 1
+      HELP
+    end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -14,6 +14,7 @@ module Anycable
     # different applications
     APP_CANDIDATES = %w[
       ./config/environment.rb
+      ./config/anycable.rb
     ].freeze
 
     def run(args)

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "optparse"
+require "pry-byebug"
+
+require "anycable"
+
+module Anycable
+  # Command-line interface for running AnyCable gRPC server
+  class CLI
+    def run(args)
+      unknown_opts = parse_cli_options!(args)
+
+      begin
+        Anycable.config.parse_options!(unknown_opts)
+      rescue OptionParser::InvalidOption => e
+        $stdout.puts e.message
+        # TODO: print usage
+        exit(1)
+      end
+
+      Anycable::Server.start
+    end
+
+    private
+
+    attr_reader :boot_file
+
+    # rubocop:disable Metrics/MethodLength
+    def parse_cli_options!(args)
+      unknown_opts = []
+
+      parser = build_cli_parser
+
+      begin
+        parser.parse!(args)
+      rescue OptionParser::InvalidOption => e
+        unknown_opts << e.args[0]
+        unless args.size.zero?
+          unknown_opts << args.shift unless args.first.start_with?("-")
+          retry
+        end
+      end
+
+      unknown_opts
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def build_cli_parser
+      OptionParser.new do |o|
+        o.on "-v", "--version", "Print version and exit" do |_arg|
+          $stdout.puts "AnyCable v#{Anycable::VERSION}"
+          exit(0)
+        end
+
+        o.on "-r", "--require [PATH|DIR]", "Location of application file to require" do |arg|
+          @boot_file = arg
+        end
+      end
+    end
+  end
+end

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -35,13 +35,19 @@ module Anycable
       http_health_path: "/health"
     )
 
-    def initialize(*)
-      super
-      # Set log params if debug is true
-      return unless debug
+    ignore_options :rpc_server_args, :redis_sentinels
+    flag_options :log_grpc, :debug
 
-      self.log_level = :debug
-      self.log_grpc = true
+    def log_level
+      debug ? :debug : @log_level
+    end
+
+    def log_grpc
+      debug || @log_grpc
+    end
+
+    def debug
+      @debug != false
     end
 
     def http_health_port_provided?
@@ -72,15 +78,6 @@ module Anycable
         port: http_health_port,
         path: http_health_path
       }
-    end
-
-    # TEMP: https://github.com/palkan/anyway_config/pull/18
-    def parse_options!(args)
-      OptionParser.new do |o|
-        o.on "--rpc-host=HOSTNAME" do |arg|
-          set_value(:rpc_host, arg)
-        end
-      end.parse!(args)
     end
   end
 end

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -73,5 +73,14 @@ module Anycable
         path: http_health_path
       }
     end
+
+    # TEMP: https://github.com/palkan/anyway_config/pull/18
+    def parse_options!(args)
+      OptionParser.new do |o|
+        o.on "--rpc-host=HOSTNAME" do |arg|
+          set_value(:rpc_host, arg)
+        end
+      end.parse!(args)
+    end
   end
 end

--- a/lib/anycable/health_server.rb
+++ b/lib/anycable/health_server.rb
@@ -36,7 +36,7 @@ module Anycable
 
       Thread.new { server.start }
 
-      logger.info "HTTP health server is listening on #{port}"
+      logger.info "HTTP health server is listening on localhost:#{port} and mounted at \"#{path}\""
     end
 
     def stop

--- a/lib/anycable/server.rb
+++ b/lib/anycable/server.rb
@@ -22,10 +22,11 @@ module Anycable
   #   server.stop
   class Server
     class << self
-      # TODO: deprecate me
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def start(**options)
-        log_grpc! if Anycable.config.log_grpc
+        warn <<~DEPRECATION
+          Using Anycable::Server.start is deprecated! Please, use anycable CLI instead.
+        DEPRECATION
 
         server = new(host: Anycable.config.rpc_host, **Anycable.config.to_grpc_params, **options)
 
@@ -48,11 +49,6 @@ module Anycable
         server.wait_till_terminated
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-
-      # FIXME: move out of server
-      def log_grpc!
-        GRPC.define_singleton_method(:logger) { Anycable.logger }
-      end
     end
 
     DEFAULT_HOST = "0.0.0.0:50051"

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -44,6 +44,19 @@ describe Anycable::Config do
       end
     end
 
+    fcontext "when REDIS_SENTINEL_HOSTS" do
+      around { |ex| with_env("ANYCABLE_REDIS_SENTINELS" => "redis-1-1:26379,redis-1-2:26380", &ex) }
+
+      subject(:config) { described_class.new }
+
+      specify do
+        expect(subject.to_redis_params).to eq(
+          url: "redis://localhost:6379/2",
+          sentinels: [{ "host" => "redis-1-1", "port" => 26_379 }, { "host" => "redis-1-2", "port" => 26_380 }]
+        )
+      end
+    end
+
     context "without sentinel" do
       before do
         config.redis_sentinels = []

--- a/spec/integrations/cli/boot_app_spec.rb
+++ b/spec/integrations/cli/boot_app_spec.rb
@@ -3,7 +3,7 @@
 require "fileutils"
 require "spec_helper"
 
-describe "CLI options", :cli do
+describe "CLI require app", :cli do
   context "when no application provided" do
     it "prints error and exit" do
       run_cli do |cli|

--- a/spec/integrations/cli/options_spec.rb
+++ b/spec/integrations/cli/options_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "CLI options", :cli do
+  describe "version" do
+    specify "-v" do
+      run_cli("-v") do |cli|
+        expect(cli).to have_stopped
+        expect(cli).to have_output_line("v#{Anycable::VERSION}")
+      end
+    end
+
+    specify "--version" do
+      run_cli("-v") do |cli|
+        expect(cli).to have_stopped
+        expect(cli).to have_output_line("v#{Anycable::VERSION}")
+      end
+    end
+  end
+
+  describe "server options" do
+    specify "--rpc-host" do
+      run_cli("--rpc-host localhost:50053") do |cli|
+        expect(cli).to have_output_line("RPC server is listening on localhost:50053")
+      end
+    end
+  end
+end

--- a/spec/integrations/cli/options_spec.rb
+++ b/spec/integrations/cli/options_spec.rb
@@ -6,22 +6,32 @@ describe "CLI options", :cli do
   describe "version" do
     specify "-v" do
       run_cli("-v") do |cli|
-        expect(cli).to have_stopped
         expect(cli).to have_output_line("v#{Anycable::VERSION}")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(0)
       end
     end
 
     specify "--version" do
-      run_cli("-v") do |cli|
-        expect(cli).to have_stopped
+      run_cli("--version") do |cli|
         expect(cli).to have_output_line("v#{Anycable::VERSION}")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(0)
+      end
+    end
+
+    specify "--help" do
+      run_cli("--help") do |cli|
+        expect(cli).to have_output_line("$ anycable [options]")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(0)
       end
     end
   end
 
   describe "server options" do
     specify "--rpc-host" do
-      run_cli("--rpc-host localhost:50053") do |cli|
+      run_cli("--rpc-host localhost:50053 -r ../spec/support/dummy.rb") do |cli|
         expect(cli).to have_output_line("RPC server is listening on localhost:50053")
       end
     end

--- a/spec/integrations/cli/options_spec.rb
+++ b/spec/integrations/cli/options_spec.rb
@@ -35,5 +35,23 @@ describe "CLI options", :cli do
         expect(cli).to have_output_line("RPC server is listening on localhost:50053")
       end
     end
+
+    specify "many options" do
+      run_cli(
+        "--rpc-host localhost:50053 -r ../spec/support/dummy.rb " \
+        "--rpc-pool-size 10 --rpc-max-waiting-requests 2 " \
+        "--rpc-poll-period 0.2 --rpc-pool-keep-alive 0.5 " \
+        "--redis-channel _test_cable_ --debug " \
+        "--http-health-port 9009 --http-health-path '/hc'"
+      ) do |cli|
+        expect(cli).to have_output_line("RPC server is listening on localhost:50053")
+        expect(cli).to have_output_line(
+          'HTTP health server is listening on localhost:9009 and mounted at "/hc"'
+        )
+        expect(cli).to have_output_line("Broadcasting Redis channel: _test_cable_")
+        # GRPC logging
+        expect(cli).to have_output_line("handling /anycable.RPC/Connect with")
+      end
+    end
   end
 end

--- a/spec/integrations/cli/run_spec.rb
+++ b/spec/integrations/cli/run_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "spec_helper"
+
+describe "CLI options", :cli do
+  context "when no application provided" do
+    it "prints error and exit" do
+      run_cli do |cli|
+        expect(cli).to have_output_line("Couldn't find an application to load")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(1)
+      end
+    end
+  end
+
+  context "when config/environment.rb is present" do
+    before do
+      FileUtils.mkdir(File.join(PROJECT_ROOT, "bin/config"))
+      FileUtils.cp(
+        File.join(PROJECT_ROOT, "spec/support/dummy_rails.rb"),
+        File.join(PROJECT_ROOT, "bin/config/environment.rb")
+      )
+    end
+
+    after do
+      FileUtils.rm_rf(File.join(PROJECT_ROOT, "bin/config"))
+    end
+
+    it "loads application" do
+      run_cli do |cli|
+        expect(cli).to have_output_line("Loading application from ./config/environment.rb ...")
+        expect(cli).to have_output_line("Rails application is loaded")
+      end
+    end
+  end
+
+  context "when require option is present" do
+    it "loads application when file exists" do
+      run_cli("-r ../spec/support/dummy.rb") do |cli|
+        expect(cli).to have_output_line("Loading application from ../spec/support/dummy.rb ...")
+        expect(cli).to have_output_line("Application is loaded")
+      end
+    end
+
+    it "prints application when file couldn't be loaded" do
+      run_cli("-r ../spec/support/dummy_fake.rb") do |cli|
+        expect(cli).to have_output_line("Loading application from ../spec/support/dummy_fake.rb ...")
+        expect(cli).to have_output_line("cannot load such file")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(1)
+      end
+    end
+  end
+end

--- a/spec/integrations/cli/signals_spec.rb
+++ b/spec/integrations/cli/signals_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "spec_helper"
+
+describe "CLI options", :cli do
+  %w[INT TERM].each do |signal|
+    it "terminates gracefully on SIG#{signal}" do
+      run_cli("-r ../spec/support/dummy.rb") do |cli|
+        expect(cli).to have_output_line("RPC server is listening")
+        cli.signal(signal)
+        expect(cli).to have_output_line("SIG#{signal} received")
+        expect(cli).to have_output_line("Stopping...")
+        expect(cli).to have_stopped
+        expect(cli).to have_exit_status(0)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ if ENV["COVER"]
   SimpleCov.start
 end
 
+PROJECT_ROOT = File.expand_path("../", __dir__)
+
 ENV["ANYCABLE_CONF"] = File.join(File.dirname(__FILE__), "support/anycable.yml")
 
 require "anycable"

--- a/spec/support/cli_testing.rb
+++ b/spec/support/cli_testing.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "pty"
+
+module CLITesting
+  class CLIControl
+    DEFAULT_WAIT_TIME = 2
+
+    attr_reader :stdout, :stderr, :pid
+
+    def initialize(stdout, stderr, pid)
+      @stdout = stdout
+      @stderr = stderr
+      @pid = pid
+      @output = []
+    end
+
+    def has_stopped?(wait: DEFAULT_WAIT_TIME)
+      loop do
+        break true unless PTY.check(pid).nil?
+        break false if wait <= 0
+
+        sleep 0.2
+        wait -= 0.2
+      end
+    end
+
+    def has_output_line?(text, wait: DEFAULT_WAIT_TIME)
+      return true if output.any? { |line| line.include?(text) }
+
+      loop do
+        line = stdout.gets&.chomp
+        raise_line_not_found!(text) if line.nil?
+
+        output << line
+        break true if line.include?(text)
+
+        raise_line_not_found!(text) if wait <= 0
+        sleep 0.2
+        wait -= 0.2
+      end
+    end
+
+    def has_exit_status?(status)
+      process_status = PTY.check(pid)
+      raise "Process is still running" if process_status.nil?
+
+      status == process_status.exitstatus
+    end
+
+    private
+
+    attr_reader :output
+
+    def raise_line_not_found!(line)
+      raise RSpec::Expectations::ExpectationNotMetError, "Expected to have in the output line: #{line}, but had instead:" \
+        "\n#{output.join("\n")}"
+    end
+  end
+
+  def run_cli(opt_string = "", chdir: nil)
+    PTY.spawn(
+      "bundle exec anycable #{opt_string}",
+      chdir: chdir || File.expand_path("../../bin", __dir__)
+    ) do |stdout, stderr, pid|
+      begin
+        yield CLIControl.new(stdout, stderr, pid)
+      ensure
+        Process.kill("SIGKILL", pid) if PTY.check(pid).nil?
+      end
+    end
+  rescue PTY::ChildExited, Errno::ESRCH
+    # no-op
+  end
+end
+
+RSpec.configure do |config|
+  config.include CLITesting, cli: true
+end

--- a/spec/support/cli_testing.rb
+++ b/spec/support/cli_testing.rb
@@ -15,6 +15,10 @@ module CLITesting
       @output = []
     end
 
+    def signal(sig)
+      Process.kill(sig, pid)
+    end
+
     def has_stopped?(wait: DEFAULT_WAIT_TIME)
       loop do
         break true if stopped?

--- a/spec/support/dummy.rb
+++ b/spec/support/dummy.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# no-op file to pass as application code

--- a/spec/support/dummy_rails.rb
+++ b/spec/support/dummy_rails.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Rails
+end


### PR DESCRIPTION
### What's inside

- Add `anycable` CLI
- Support passing Redis Sentinel config as string (e.g. though ENV)
- Deprecate `Anycable::Server.start`