### PR TITLE
Add anycabled binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## master
 
+- Allow running the server as a detachable daemon ([@sponomarev][])
+
+Server is fully managed by the binary itself.
+
+```
+# Start anycable daemon
+$ bundle exec anycabled start
+
+# Pass cli options to anycable through daemon. Separate daemon options and anycable options with `--`
+$ bundle exec anycabled start -- --rpc-host 127.0.0.1:31337
+
+# Stop anycable daemon
+$ bundle exec anycabled stop
+
+# See more anycable daemon options
+$ bundle exec anycabled
+```
+
 ## 0.6.1 (2019-01-05)
 
 - [Fix #63](https://github.com/anycable/anycable-rails/issues/63) Load `anyway_config` after application boot to make sure that all frameworks dependent functionality is loaded. ([@palkan][])
@@ -116,7 +134,7 @@ Minor fixes.
 
 - [#28](https://github.com/anycable/anycable/issues/28) Support arbitrary headers. ([@palkan][])
 
-Previously we hardcoded only "Cookie" header. Now we add all passed headers by WebSocket server to request env. 
+Previously we hardcoded only "Cookie" header. Now we add all passed headers by WebSocket server to request env.
 
 - [#27](https://github.com/anycable/anycable/issues/27) Add `error_msg` to RPC responses. ([@palkan][])
 
@@ -130,7 +148,7 @@ We provide `error_msg` only when request status is `ERROR`.
 
 - [#25](https://github.com/anycable/anycable/issues/25) Improve logging and exceptions handling. ([@palkan][])
 
-Default logger logs to STDOUT with `info` level by default but can be configured to log to file with 
+Default logger logs to STDOUT with `info` level by default but can be configured to log to file with
 any severity.
 
 GRPC logging is turned off by default (can be turned on through `log_grpc` configuration parameter).

--- a/anycable.gemspec
+++ b/anycable.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/anycable/anycable"
   spec.license       = "MIT"
 
-  spec.executables   = ["anycable"]
+  spec.executables   = %w[anycable anycabled]
   spec.files         = `git ls-files README.md MIT-LICENSE CHANGELOG.md lib bin`.split
   spec.require_paths = ["lib"]
 

--- a/bin/anycable
+++ b/bin/anycable
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require_relative "../lib/anycable/cli"
+require "anycable/cli"
 
 begin
   cli = AnyCable::CLI.new

--- a/bin/anycabled
+++ b/bin/anycabled
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require "anycable/cli"
+
+begin
+  require "daemons"
+rescue LoadError
+  raise <<~MSG
+    You need to add gem 'daemons' to your Gemfile if you want to use `anycabled`:
+
+      # Gemfile
+      gem "daemons", "~> 1.3", require: false
+  MSG
+end
+
+options = {
+  dir: "tmp/pids",
+  log_otput: false
+}
+
+# Preserve current directory. We need it inside the server.
+current_dir = Dir.pwd
+
+Daemons.run_proc("anycable", options) do
+  Dir.chdir current_dir
+  AnyCable::CLI.new.run
+end

--- a/bin/anycabled
+++ b/bin/anycabled
@@ -21,7 +21,10 @@ options = {
 # Preserve current directory. We need it inside the server.
 current_dir = Dir.pwd
 
+# Clean ARGV from daemon command and args
+_, _, args = Daemons::Controller.split_argv(ARGV)
+
 Daemons.run_proc("anycable", options) do
   Dir.chdir current_dir
-  AnyCable::CLI.new.run
+  AnyCable::CLI.new.run(args)
 end

--- a/bin/anycabled
+++ b/bin/anycabled
@@ -15,7 +15,7 @@ end
 
 options = {
   dir: "tmp/pids",
-  log_otput: false
+  log_output: false
 }
 
 # Preserve current directory. We need it inside the server.

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -23,7 +23,7 @@ module AnyCable
     attr_reader :server, :health_server
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    def run(args)
+    def run(args = {})
       @at_stop = []
 
       extra_options = parse_cli_options!(args)


### PR DESCRIPTION
The motivation is simple - provide a way to deploy it with ~good old~ Capistrano.

I tried to minimize my changes as little as possible wrapping application into a separate daemon binary. Limitation - anycable cli args are not handled, I'll update the docs separately. 