### PR TITLE
Add GRPC service method name and message content to exception notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## master
 
+- Add GRPC service method name and message content to exception notifications ([@sponomarev][])
+
+`Anycable.capture_exception` allows accessing GRPC service method name and message content
+on which an exception was captured. It can be used for exceptions grouping in your tracker and
+providing additional data to investigate a root of a problem.
+
+Example:
+
+```ruby
+AnyCable.capture_exception do |ex, method, message|
+  Honeybadger.notify(ex, component: "any_cable", action: method, params: message)
+end
+```
+
+Usage of a handler proc with just a single argument is preserved for the sake of compatibility.
+
 - Add deprecation warning to default host usage ([@sponomarev][])
 
 Exposing AnyCable publicly is considered to be harmful and planned to be changed

--- a/lib/anycable/exceptions_handling.rb
+++ b/lib/anycable/exceptions_handling.rb
@@ -4,15 +4,15 @@ module AnyCable
   module ExceptionsHandling # :nodoc:
     class << self
       def add_handler(block)
-        handlers << block
+        handlers << procify(block)
       end
 
       alias << add_handler
 
-      def notify(exp)
+      def notify(exp, method_name, message)
         handlers.each do |handler|
           begin
-            handler.call(exp)
+            handler.call(exp, method_name, message)
           rescue StandardError => exp
             AnyCable.logger.error "!!! EXCEPTION HANDLER THREW AN ERROR !!!"
             AnyCable.logger.error exp
@@ -22,6 +22,12 @@ module AnyCable
       end
 
       private
+
+      def procify(block)
+        return block unless block.lambda?
+
+        proc { |*args| block.call(*args.take(block.arity)) }
+      end
 
       def handlers
         @handlers ||= []

--- a/lib/anycable/handler/capture_exceptions.rb
+++ b/lib/anycable/handler/capture_exceptions.rb
@@ -18,16 +18,16 @@ module AnyCable
 
       RESPONSE_CLASS.keys.each do |mid|
         module_eval <<~CODE, __FILE__, __LINE__ + 1
-          def #{mid}(*)
-            capture_exceptions(:#{mid}) { super }
+          def #{mid}(message, *)
+            capture_exceptions(:#{mid}, message) { super }
           end
         CODE
       end
 
-      def capture_exceptions(method_name)
+      def capture_exceptions(method_name, message)
         yield
       rescue StandardError => exp
-        AnyCable::ExceptionsHandling.notify(exp)
+        AnyCable::ExceptionsHandling.notify(exp, method_name.to_s, message.to_h)
 
         RESPONSE_CLASS.fetch(method_name).new(
           status: AnyCable::Status::ERROR,

--- a/spec/integrations/grpc/connection_spec.rb
+++ b/spec/integrations/grpc/connection_spec.rb
@@ -15,6 +15,23 @@ describe "client connection", :with_grpc_server do
     end
   end
 
+  context "when exception" do
+    let(:request) do
+      AnyCable::ConnectionRequest.new(
+        path: "http://example.io/cable?raise=sudden_connect_error"
+      )
+    end
+    it "responds with ERROR", :aggregate_failures do
+      expect(subject.status).to eq :ERROR
+      expect(subject.error_msg).to eq("sudden_connect_error")
+    end
+
+    it "notifies exception handler" do
+      subject
+      expect(TestExHandler.last_error.message).to eq("sudden_connect_error")
+    end
+  end
+
   context "with cookies and path info" do
     let(:request) do
       AnyCable::ConnectionRequest.new(

--- a/spec/integrations/grpc/connection_spec.rb
+++ b/spec/integrations/grpc/connection_spec.rb
@@ -28,7 +28,12 @@ describe "client connection", :with_grpc_server do
 
     it "notifies exception handler" do
       subject
-      expect(TestExHandler.last_error.message).to eq("sudden_connect_error")
+
+      expect(TestExHandler.last_error).to have_attributes(
+        exception: have_attributes(message: "sudden_connect_error"),
+        method: "connect",
+        message: request.to_h
+      )
     end
   end
 

--- a/spec/integrations/grpc/disconnection_spec.rb
+++ b/spec/integrations/grpc/disconnection_spec.rb
@@ -30,4 +30,18 @@ describe "disconnection", :with_grpc_server, :rpc_command do
       expect(log.last[:data]).to eq(name: "disco", path: "/cable_lite", subscriptions: %w[a b])
     end
   end
+
+  context "when exception" do
+    let(:url) { "http://example.io/cable_lite?raise=sudden_disconnect_error" }
+
+    it "responds with ERROR", :aggregate_failures do
+      expect(subject.status).to eq :ERROR
+      expect(subject.error_msg).to eq("sudden_disconnect_error")
+    end
+
+    it "notifies exception handler" do
+      subject
+      expect(TestExHandler.last_error.message).to eq("sudden_disconnect_error")
+    end
+  end
 end

--- a/spec/integrations/grpc/disconnection_spec.rb
+++ b/spec/integrations/grpc/disconnection_spec.rb
@@ -41,7 +41,12 @@ describe "disconnection", :with_grpc_server, :rpc_command do
 
     it "notifies exception handler" do
       subject
-      expect(TestExHandler.last_error.message).to eq("sudden_disconnect_error")
+
+      expect(TestExHandler.last_error).to have_attributes(
+        exception: have_attributes(message: "sudden_disconnect_error"),
+        method: "disconnect",
+        message: request.to_h
+      )
     end
   end
 end

--- a/spec/integrations/grpc/perform_spec.rb
+++ b/spec/integrations/grpc/perform_spec.rb
@@ -52,7 +52,12 @@ describe "client messages", :with_grpc_server, :rpc_command do
 
       it "notifies exception handler" do
         subject
-        expect(TestExHandler.last_error.message).to match(/can't be coerced/)
+
+        expect(TestExHandler.last_error).to have_attributes(
+          exception: have_attributes(message: a_string_matching(/can't be coerced/)),
+          method: "command",
+          message: request.to_h
+        )
       end
     end
   end

--- a/spec/integrations/grpc/perform_spec.rb
+++ b/spec/integrations/grpc/perform_spec.rb
@@ -49,6 +49,11 @@ describe "client messages", :with_grpc_server, :rpc_command do
         expect(subject.status).to eq :ERROR
         expect(subject.error_msg).to match(/can't be coerced/)
       end
+
+      it "notifies exception handler" do
+        subject
+        expect(TestExHandler.last_error.message).to match(/can't be coerced/)
+      end
     end
   end
 end

--- a/spec/integrations/grpc/subscriptions_spec.rb
+++ b/spec/integrations/grpc/subscriptions_spec.rb
@@ -100,7 +100,12 @@ describe "subscriptions", :with_grpc_server, :rpc_command do
 
     it "notifies exception handler" do
       subject
-      expect(TestExHandler.last_error.message).to eq "Unknown command"
+
+      expect(TestExHandler.last_error).to have_attributes(
+        exception: have_attributes(message: "Unknown command"),
+        method: "command",
+        message: request.to_h
+      )
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,10 @@ module TestExHandler
     def call(exp)
       @last_error = exp
     end
+
+    def flush!
+      @last_error = nil
+    end
   end
 end
 
@@ -56,5 +60,6 @@ RSpec.configure do |config|
   config.after(:each) do
     Anyway.env.clear if defined?(Anyway)
     AnyCable.logger.reset if AnyCable.logger.respond_to?(:reset)
+    TestExHandler.flush!
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,11 +25,13 @@ AnyCable.logger = TestLogger.new
 AnyCable::Server.log_grpc! if ENV["LOG"]
 
 module TestExHandler
+  Error = Struct.new(:exception, :method, :message)
+
   class << self
     attr_reader :last_error
 
-    def call(exp)
-      @last_error = exp
+    def call(exp, method, message)
+      @last_error = Error.new(exp, method, message)
     end
 
     def flush!

--- a/spec/support/test_factory.rb
+++ b/spec/support/test_factory.rb
@@ -13,6 +13,8 @@ module AnyCable
       end
 
       def handle_open
+        raise request.params["raise"] if request.params["raise"]
+
         @identifiers["current_user"] = request.cookies["username"]
         @identifiers["path"] = request.path
         @identifiers["token"] = request.params["token"] || request.get_header("HTTP_X_API_TOKEN")
@@ -26,6 +28,8 @@ module AnyCable
       end
 
       def handle_close
+        raise request.params["raise"] if request.params["raise"]
+
         TestFactory.log_event(
           "disconnect",
           name: @identifiers["current_user"],


### PR DESCRIPTION
`Anycable.capture_exception` allows accessing GRPC service method name and message content
on which an exception was captured. It can be used for exceptions grouping in your tracker and
providing additional data to investigate a root of a problem.

Example:

```ruby
AnyCable.capture_exception do |ex, method, message|
  Honeybadger.notify(ex, component: "any_cable", action: method, params: message)
end
```

Usage of a handler proc with just a single argument is preserved for the sake of compatibility.