### PR TITLE
Add `REMOTE_ADDR` socket env variable using a synthetic header passed from a websocket server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+– Add `REMOTE_ADDR` socket env variable using a synthetic header passed from a websocket
+server. ([@sponomarev][])
+
+Recreating a request object in your custom connection factory using `Rack::Request` or
+`ActionDispatch::Request` (already implemented in [anycable-rails](https://github.com/anycable/anycable-rails))
+gives you an access to `request.ip` with the properly set IP address.
+
 - Align socket env to be more compatibile with Rack Spec ([@sponomarev][])
 
 Provide as much env details as possible to be able to reconstruct the full
@@ -249,3 +256,4 @@ Implement `Disconnect` handler, which invokes `Connection#disconnect` (along wit
 [@sadovnik]: https://github.com/sadovnik
 [@accessd]: https://github.com/accessd
 [@DarthSim]: https://github.com/DarthSim
+[@sponomarev]: https://github.com/sponomarev

--- a/lib/anycable/rpc_handler.rb
+++ b/lib/anycable/rpc_handler.rb
@@ -100,8 +100,9 @@ module AnyCable
     # Build Rack env from request
     def rack_env(request)
       uri = URI.parse(request.path)
-      {
-        # Minimum required variables according to Rack Spec
+
+      # Minimum required variables according to Rack Spec
+      env = {
         "REQUEST_METHOD" => "GET",
         "SCRIPT_NAME" => "",
         "PATH_INFO" => uri.path,
@@ -109,9 +110,12 @@ module AnyCable
         "SERVER_NAME" => uri.host,
         "SERVER_PORT" => uri.port.to_s,
         "HTTP_HOST" => uri.host,
+        "REMOTE_ADDR" => request.headers.delete("REMOTE_ADDR"),
         "rack.url_scheme" => uri.scheme,
         "rack.input" => ""
-      }.merge(build_headers(request.headers))
+      }
+
+      env.merge!(build_headers(request.headers))
     end
 
     def build_socket(**options)

--- a/spec/support/test_factory.rb
+++ b/spec/support/test_factory.rb
@@ -18,7 +18,8 @@ module AnyCable
         @identifiers["current_user"] = request.cookies["username"]
         @identifiers["path"] = request.path
         @identifiers["token"] = request.params["token"] || request.get_header("HTTP_X_API_TOKEN")
-        @identifiers["remote_ip"] = request.ip
+        @identifiers["ip"] = request.ip
+        @identifiers["remote_addr"] = request.get_header("HTTP_REMOTE_ADDR")
         @identifiers["env"] = socket.env
 
         if @identifiers["current_user"]


### PR DESCRIPTION
Recreating a request object in your custom connection factory using `Rack::Request` or
`ActionDispatch::Request` (already implemented in [anycable-rails](https://github.com/anycable/anycable-rails)) gives you an access to `request.ip` with the properly set IP address.

Symmetric change in the WS server https://github.com/anycable/anycable-go/pull/71 See it for the implementation motivation.