### PR TITLE
Require webrick only if health server is enabled

### DIFF
--- a/lib/anycable/health_server.rb
+++ b/lib/anycable/health_server.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "webrick"
-
 module AnyCable
   # Server for HTTP healthchecks.
   #
@@ -53,6 +51,8 @@ module AnyCable
     attr_reader :logger
 
     def build_server
+      require "webrick"
+
       WEBrick::HTTPServer.new(
         Port: port,
         Logger: logger,


### PR DESCRIPTION
This reduces the gem boot memory footprint:

- Before:

```
anycable: 7.3359 MiB
    anycable/middleware_chain: 4.1953 MiB
      anycable/middleware: 4.1953 MiB
        grpc: 4.1953 MiB
    anycable/server: 2.8945 MiB
      anycable/health_server: 3.0 MiB
        webrick: 3.0 MiB
```

- After:

```
anycable: 4.3359 MiB
    anycable/middleware_chain: 4.2109 MiB
      anycable/middleware: 4.2109 MiB
        grpc: 4.2109 MiB
```

Closes https://github.com/anycable/anycable-rails/issues/109.

