### PR TITLE
Relax anyway_config version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Now you can access `request` object in channels, too (e.g., to read headers/cook
 
 See [#71](https://github.com/anycable/anycable/pull/71).
 
+- Relax `anyway_config` dependency to have an ability to use its next major version. ([@bibendi])
+
 ## 0.6.4 (2020-01-24)
 
 - Fix Ruby 2.7 warnings. ([@palkan])
@@ -281,3 +283,4 @@ Implement `Disconnect` handler, which invokes `Connection#disconnect` (along wit
 [@accessd]: https://github.com/accessd
 [@DarthSim]: https://github.com/DarthSim
 [@sponomarev]: https://github.com/sponomarev
+[@bibendi]: https://github.com/bibendi

--- a/anycable.gemspec
+++ b/anycable.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.add_dependency "anyway_config", "~> 1.4.2"
+  spec.add_dependency "anyway_config", ">= 1.4.2", "< 3"
   spec.add_dependency "grpc", "~> 1.17"
 
   spec.add_development_dependency "redis", ">= 4.0"


### PR DESCRIPTION
I want to use the latest version of `anyway_config` in my project, but `anycable` doesn't allow me to do that.
I'm going to make sure that everything works well with this change, so don't merge the PR before that.

BTW, @palkan shouldn't you want to roll out the `anyway_config`? In Aprill will be one year since you started developing that version :)