### PR TITLE
HTTP broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 🚧 1.0.0 (_coming soon_)
 
+- Add `:http` broadcasting adapter. ([@palkan][])
+
 - **RPC schema has changed**. ([@palkan][])
 
 Using `anycable-go` v1.x is required.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AnyCable uses the same protocol as ActionCable, so you can use its [JavaScript c
 ## Requirements
 
 - Ruby >= 2.5
-- Redis (for broadcasting, [discuss other options](https://github.com/anycable/anycable/issues/2) with us!)
+- Redis (for broadcasting **in production**, [discuss other options](https://github.com/anycable/anycable/issues/2) with us!)
 
 ## Usage
 

--- a/anycable.gemspec
+++ b/anycable.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rack", "~> 2.0"
   spec.add_development_dependency "rspec", ">= 3.5"
+  spec.add_development_dependency "webmock", "~> 3.8"
 end

--- a/lib/anycable.rb
+++ b/lib/anycable.rb
@@ -67,7 +67,7 @@ module AnyCable
     end
 
     def broadcast_adapter
-      self.broadcast_adapter = :redis unless instance_variable_defined?(:@broadcast_adapter)
+      self.broadcast_adapter = AnyCable.config.broadcast_adapter.to_sym unless instance_variable_defined?(:@broadcast_adapter)
       @broadcast_adapter
     end
 

--- a/lib/anycable/broadcast_adapters.rb
+++ b/lib/anycable/broadcast_adapters.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "anycable/broadcast_adapters/base"
+
 module AnyCable
   module BroadcastAdapters # :nodoc:
     module_function

--- a/lib/anycable/broadcast_adapters/base.rb
+++ b/lib/anycable/broadcast_adapters/base.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module AnyCable
+  module BroadcastAdapters
+    class Base
+      def broadcast(_stream, _payload)
+        raise NotImplementedError
+      end
+
+      def announce!
+        logger.info "Broadcasting via #{self.class.name}"
+      end
+
+      private
+
+      def logger
+        AnyCable.logger
+      end
+    end
+  end
+end

--- a/lib/anycable/broadcast_adapters/http.rb
+++ b/lib/anycable/broadcast_adapters/http.rb
@@ -40,10 +40,15 @@ module AnyCable
       MAX_ATTEMPTS = 3
       DELAY = 2
 
-      attr_reader :url
+      attr_reader :url, :headers
 
-      def initialize(url: AnyCable.config.http_broadcast_url)
+      def initialize(url: AnyCable.config.http_broadcast_url, secret: AnyCable.config.http_broadcast_secret)
         @url = url
+        @headers = {}.tap do |headers|
+          next unless secret
+          headers["Authorization"] = "Bearer #{secret}"
+        end
+
         @uri = URI.parse(url)
         @queue = Queue.new
       end
@@ -81,7 +86,7 @@ module AnyCable
 
       def perform_request(payload)
         build_http do |http|
-          req = Net::HTTP::Post.new(url, {"Content-Type" => "application/json"})
+          req = Net::HTTP::Post.new(url, {"Content-Type" => "application/json"}.merge(headers))
           req.body = payload
           http.request(req)
         end

--- a/lib/anycable/broadcast_adapters/http.rb
+++ b/lib/anycable/broadcast_adapters/http.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+require "net/http"
+
+module AnyCable
+  module BroadcastAdapters
+    # HTTP adapter for broadcasting.
+    #
+    # Example:
+    #
+    #   AnyCable.broadast_adapter = :http
+    #
+    # It uses configuration from global AnyCable config
+    # by default.
+    #
+    # You can override these params:
+    #
+    #   AnyCable.broadcast_adapter = :http, url: "http://ws.example.com/_any_cable_"
+    class Http
+      # Taken from: https://github.com/influxdata/influxdb-ruby/blob/886058079c66d4fd019ad74ca11342fddb0b753d/lib/influxdb/errors.rb#L18
+      RECOVERABLE_EXCEPTIONS = [
+        Errno::ECONNABORTED,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET,
+        Errno::EHOSTUNREACH,
+        Errno::EINVAL,
+        Errno::ENETUNREACH,
+        Net::HTTPBadResponse,
+        Net::HTTPHeaderSyntaxError,
+        Net::ProtocolError,
+        SocketError,
+        (OpenSSL::SSL::SSLError if defined?(OpenSSL))
+      ].compact.freeze
+
+      OPEN_TIMEOUT = 5
+      READ_TIMEOUT = 10
+
+      MAX_ATTEMPTS = 3
+      DELAY = 2
+
+      attr_reader :url
+
+      def initialize(url: AnyCable.config.http_broadcast_url)
+        @url = url
+        @uri = URI.parse(url)
+      end
+
+      def broadcast(stream, payload)
+        payload = {stream: stream, data: payload}.to_json
+
+        build_http do |http|
+          req = Net::HTTP::Post.new(url, {"Content-Type" => "application/json"})
+          req.body = payload
+          http.request(req)
+        end
+      end
+
+      private
+
+      attr_reader :uri
+
+      def build_http
+        retry_count = 0
+
+        begin
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.open_timeout = OPEN_TIMEOUT
+          http.read_timeout = READ_TIMEOUT
+          yield http
+        rescue Timeout::Error, *RECOVERABLE_EXCEPTIONS
+          retry_count += 1
+          raise if MAX_ATTEMPTS < retry_count
+
+          sleep((DELAY**retry_count) * retry_count)
+          retry
+        ensure
+          http.finish if http.started?
+        end
+      end
+    end
+  end
+end

--- a/lib/anycable/broadcast_adapters/redis.rb
+++ b/lib/anycable/broadcast_adapters/redis.rb
@@ -19,7 +19,7 @@ module AnyCable
     # You can override these params:
     #
     #   AnyCable.broadcast_adapter = :redis, url: "redis://my_redis", channel: "_any_cable_"
-    class Redis
+    class Redis < Base
       attr_reader :redis_conn, :channel
 
       def initialize(
@@ -36,6 +36,10 @@ module AnyCable
           channel,
           {stream: stream, data: payload}.to_json
         )
+      end
+
+      def announce!
+        logger.info "Broadcasting Redis channel: #{channel}"
       end
     end
   end

--- a/lib/anycable/cli.rb
+++ b/lib/anycable/cli.rb
@@ -183,7 +183,7 @@ module AnyCable
     end
 
     def start_pubsub!
-      logger.info "Broadcasting Redis channel: #{config.redis_channel}"
+      AnyCable.broadcast_adapter.announce!
     end
 
     # rubocop: disable Metrics/MethodLength, Metrics/AbcSize
@@ -313,15 +313,22 @@ module AnyCable
             -r, --require=path                Location of application file to require, default: "config/environment.rb"
             --server-command=command          Command to run WebSocket server
             --rpc-host=host                   Local address to run gRPC server on, default: "[::]:50051"
-            --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
-            --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
-            --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
+            --broadcast-adapter=type          Pub/sub adapter type for broadcasts, default: redis
             --log-level=level                 Logging level, default: "info"
             --log-file=path                   Path to log file, default: <none> (log to STDOUT)
             --log-grpc                        Enable gRPC logging (disabled by default)
             --debug                           Turn on verbose logging ("debug" level and gRPC logging on)
             -v, --version                     Print version and exit
             -h, --help                        Show this help
+
+        REDIS PUB/SUB OPTIONS
+            --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
+            --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
+            --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
+
+        HTTP PUB/SUB OPTIONS
+            --http-broadcast-url              HTTP pub/sub endpoint URL, default: "http://localhost:8090/_broadcast"
+            --http-broadcast-secret           HTTP pub/sub authorization secret, default: <none> (disabled)
 
         HTTP HEALTH CHECKER OPTIONS
             --http-health-port=port           Port to run HTTP health server on, default: <none> (disabled)

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -19,6 +19,9 @@ module AnyCable
       # See https://github.com/grpc/grpc/blob/f526602bff029b8db50a8d57134d72da33d8a752/include/grpc/impl/codegen/grpc_types.h#L292-L315
       rpc_server_args: {},
 
+      ## PubSub
+      broadcast_adapter: :redis,
+
       ### Redis options
       redis_url: ENV.fetch("REDIS_URL", "redis://localhost:6379/5"),
       redis_sentinels: nil,

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -24,6 +24,10 @@ module AnyCable
       redis_sentinels: nil,
       redis_channel: "__anycable__",
 
+      ### HTTP broadcasting options
+      http_broadcast_url: "http://localhost:8090/_broadcast",
+      http_broadcast_secret: nil,
+
       ### Logging options
       log_file: nil,
       log_level: :info,

--- a/spec/anycable/broadcast_adapters/http_spec.rb
+++ b/spec/anycable/broadcast_adapters/http_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "anycable/broadcast_adapters/http"
+
+describe AnyCable::BroadcastAdapters::Http do
+  before do
+    config.http_broadcast_url = "http://ws.example.com/_broadcast"
+  end
+
+  after { AnyCable.config.reload }
+
+  let(:config) { AnyCable.config }
+
+  it "uses config options by default" do
+    adapter = described_class.new
+    expect(adapter.url).to eq "http://ws.example.com/_broadcast"
+  end
+
+  it "uses override config params" do
+    adapter = described_class.new(url: "http://example.com/ws/_broadcast")
+    expect(adapter.url).to eq "http://example.com/ws/_broadcast"
+  end
+
+  describe "#broadcast" do
+    subject { described_class.new }
+
+    it "publish data to channel" do
+      stub_request(:post, "http://ws.example.com/_broadcast").to_return(status: 201)
+
+      subject.broadcast("notification", "hello!")
+
+      expect(a_request(:post, "http://ws.example.com/_broadcast")
+        .with(body: {stream: "notification", data: "hello!"}.to_json))
+        .to have_been_made.once
+    end
+
+    context "retries" do
+      let(:adapter) { described_class.new }
+      subject { adapter.broadcast("notification", "hello!") }
+
+      before do
+        allow(adapter).to receive(:sleep)
+      end
+
+      it "handles TimeoutError and retries" do
+        stub_request(:post, "http://ws.example.com/_broadcast")
+          .to_raise(Timeout::Error).then
+          .to_return(status: 201)
+
+        expect { subject }.not_to raise_error
+
+        expect(a_request(:post, "http://ws.example.com/_broadcast")
+          .with(body: {stream: "notification", data: "hello!"}.to_json))
+          .to have_been_made.twice
+      end
+
+      it "retires only 2 times" do
+        stub_request(:post, "http://ws.example.com/_broadcast")
+          .to_raise(Timeout::Error).then
+          .to_raise(Net::HTTPBadResponse).then
+          .to_raise(Timeout::Error)
+
+        expect { subject }.to raise_error(Timeout::Error)
+      end
+    end
+  end
+end

--- a/spec/anycable/broadcast_adapters/http_spec.rb
+++ b/spec/anycable/broadcast_adapters/http_spec.rb
@@ -24,45 +24,109 @@ describe AnyCable::BroadcastAdapters::Http do
   end
 
   describe "#broadcast" do
-    subject { described_class.new }
+    let(:adapter) { described_class.new(url: "http://ws.example.com:8090/_broadcast") }
+    subject { adapter }
 
     it "publish data to channel" do
-      stub_request(:post, "http://ws.example.com/_broadcast").to_return(status: 201)
+      stub_request(:post, "http://ws.example.com:8090/_broadcast").to_return(status: 201)
 
       subject.broadcast("notification", "hello!")
 
-      expect(a_request(:post, "http://ws.example.com/_broadcast")
+      # make sure thread has processed messages
+      subject.shutdown
+
+      expect(a_request(:post, "http://ws.example.com:8090/_broadcast")
         .with(body: {stream: "notification", data: "hello!"}.to_json))
         .to have_been_made.once
     end
 
+    it "print debug message if response is not 201" do
+      allow(AnyCable.logger).to receive(:debug)
+      stub_request(:post, "http://ws.example.com:8090/_broadcast").to_return(status: 403)
+
+      subject.broadcast("notification", "hello!")
+
+      # make sure thread has processed messages
+      subject.shutdown
+
+      expect(a_request(:post, "http://ws.example.com:8090/_broadcast")
+        .with(body: {stream: "notification", data: "hello!"}.to_json))
+        .to have_been_made.once
+
+      expect(AnyCable.logger).to have_received(:debug).with(/Broadcast request responded with unexpected status: 403/)
+    end
+
     context "retries" do
-      let(:adapter) { described_class.new }
       subject { adapter.broadcast("notification", "hello!") }
 
       before do
         allow(adapter).to receive(:sleep)
+        allow(AnyCable.logger).to receive(:error)
       end
 
       it "handles TimeoutError and retries" do
-        stub_request(:post, "http://ws.example.com/_broadcast")
+        stub_request(:post, "http://ws.example.com:8090/_broadcast")
           .to_raise(Timeout::Error).then
           .to_return(status: 201)
 
-        expect { subject }.not_to raise_error
+        subject
 
-        expect(a_request(:post, "http://ws.example.com/_broadcast")
+        # make sure thread has processed messages
+        adapter.shutdown
+
+        expect(AnyCable.logger).not_to have_received(:error)
+
+        expect(a_request(:post, "http://ws.example.com:8090/_broadcast")
           .with(body: {stream: "notification", data: "hello!"}.to_json))
           .to have_been_made.twice
       end
 
       it "retires only 2 times" do
-        stub_request(:post, "http://ws.example.com/_broadcast")
+        stub_request(:post, "http://ws.example.com:8090/_broadcast")
           .to_raise(Timeout::Error).then
-          .to_raise(Net::HTTPBadResponse).then
+          .to_raise(Net::ProtocolError).then
           .to_raise(Timeout::Error)
 
-        expect { subject }.to raise_error(Timeout::Error)
+        subject
+
+        # make sure thread has processed messages
+        adapter.shutdown
+
+        expect(AnyCable.logger).to have_received(:error).with(/Broadcast request failed/)
+      end
+
+      context "thread keepalive" do
+        it "re-creates a thread of exception" do
+          stub_request(:post, "http://ws.example.com:8090/_broadcast")
+            .to_raise(RuntimeError).then
+            .to_return(status: 201)
+
+          # silent thread exceptions
+          adapter.send(:ensure_thread_is_alive)
+          adapter.send(:thread).report_on_exception = false
+
+          subject
+
+          # make sure thread has processed messages
+          adapter.shutdown
+          # remove stop frame which haven't been processed by the dead thread
+          expect(adapter.send(:queue).pop).to eq :stop
+
+          expect(AnyCable.logger).to have_received(:error).with(/Broadcasting thread exited with exception/)
+
+          adapter.broadcast("notification", "hi again!")
+
+          # make sure thread has processed messages
+          adapter.shutdown
+
+          expect(a_request(:post, "http://ws.example.com:8090/_broadcast")
+            .with(body: {stream: "notification", data: "hello!"}.to_json))
+            .to have_been_made
+
+          expect(a_request(:post, "http://ws.example.com:8090/_broadcast")
+            .with(body: {stream: "notification", data: "hi again!"}.to_json))
+            .to have_been_made
+        end
       end
     end
   end

--- a/spec/anycable/broadcast_adapters/http_spec.rb
+++ b/spec/anycable/broadcast_adapters/http_spec.rb
@@ -74,8 +74,7 @@ describe AnyCable::BroadcastAdapters::Http do
           .with(
             body: {stream: "notification", data: "hello!"}.to_json,
             headers: {"Authorization" => "Bearer any-secret"}
-          )
-        ).to have_been_made.once
+          )).to have_been_made.once
       end
     end
 

--- a/spec/integrations/cli/options_spec.rb
+++ b/spec/integrations/cli/options_spec.rb
@@ -23,6 +23,11 @@ describe "CLI options", :cli do
     specify "--help" do
       run_cli("--help") do |cli|
         expect(cli).to have_output_line("$ anycable [options]")
+        expect(cli).to have_output_line("BASIC OPTIONS")
+        expect(cli).to have_output_line("REDIS PUB/SUB OPTIONS")
+        expect(cli).to have_output_line("HTTP PUB/SUB OPTIONS")
+        expect(cli).to have_output_line("HTTP HEALTH CHECKER OPTIONS")
+        expect(cli).to have_output_line("GRPC OPTIONS")
         expect(cli).to have_stopped
         expect(cli).to have_exit_status(0)
       end
@@ -51,6 +56,18 @@ describe "CLI options", :cli do
         expect(cli).to have_output_line("Broadcasting Redis channel: _test_cable_")
         # GRPC logging
         expect(cli).to have_output_line("handling /anycable.RPC/Connect with")
+      end
+    end
+
+    specify "http broadcast options" do
+      run_cli(
+        "--rpc-host 0.0.0.0:50053 -r ../spec/dummies/app.rb " \
+        "--broadcast-adapter=http " \
+        "--http-broadcast-url=http://my-ws.com/_broadcast/me " \
+        "--http-broadcast-secret=test"
+      ) do |cli|
+        expect(cli).to have_output_line("RPC server is listening on 0.0.0.0:50053")
+        expect(cli).to have_output_line("Broadcasting HTTP url: http://my-ws.com/_broadcast/me (with authorization)")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@ require "rack"
 
 require "anycable/rspec"
 
+require "webmock/rspec"
+WebMock.disable_net_connect!(allow_localhost: true)
+
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 AnyCable.connection_factory = AnyCable::TestFactory


### PR DESCRIPTION
### What is the purpose of this pull request?

Add support for HTTP broadcasting.
This should eliminate Redis dependency and make it easy to play with AnyCable.

Related to #2.

### What changes did you make? (overview)

- [x] Added `:http` broadcast adapter
- [x] Added `--broadcast-adapter` configuration and CLI option.

### Checklist

- [x] Include tests for this change
- [x] Add Changelog entry
- [x] Update documentation for this change (if appropriate) https://github.com/anycable/docs.anycable.io/pull/26
