### PR TITLE
Making redis command line arguments the same across AnyCable libraries and documentation.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will b
 
 [Broadcast adapter](./broadcast_adapters.md) to use. Available options out-of-the-box: `redis` (default), `http`.
 
-**redis_url** (`REDIS_URL`, `ANYCABLE_REDIS_URL`, `--redis-url`)
+**redis_url** (`REDIS_URL`, `ANYCABLE_REDIS_URL`, `--redis_url`)
 
 Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ You can also pass configuration variables to CLI as options, e.g.:
 
 ```sh
 $ bundle exec anycable --rpc-host 0.0.0.0:50120 \
-                       --redis-channel my_redis_channel \
+                       --redis_channel my_redis_channel \
                        --log-level debug
 ```
 
@@ -33,7 +33,7 @@ Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will b
 
 Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 
-**redis_channel** (`ANYCABLE_REDIS_CHANNEL`, `--redis-channel`)
+**redis_channel** (`ANYCABLE_REDIS_CHANNEL`, `--redis_channel`)
 
 Redis channel for broadcasting (default: `"__anycable__"`).
 

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -79,7 +79,7 @@ module AnyCable
 
       REDIS PUB/SUB
           --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
-          --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
+          --redis_channel=name              Redis channel for broadcasting, default: "__anycable__"
           --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
 
       HTTP PUB/SUB

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -78,9 +78,9 @@ module AnyCable
           --http-health-path=path           Endpoint to serve health checks, default: "/health"
 
       REDIS PUB/SUB
-          --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
+          --redis_url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
           --redis_channel=name              Redis channel for broadcasting, default: "__anycable__"
-          --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
+          --redis_sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
 
       HTTP PUB/SUB
           --http-broadcast-url              HTTP pub/sub endpoint URL, default: "http://localhost:8090/_broadcast"

--- a/spec/integrations/cli/options_spec.rb
+++ b/spec/integrations/cli/options_spec.rb
@@ -35,7 +35,7 @@ describe "CLI options", :cli do
   specify "many options" do
     run_cli(
       "-r ../spec/dummies/app.rb " \
-      "--redis-channel _test_cable_ --debug " \
+      "--redis_channel _test_cable_ --debug " \
       "--http-health-port 9009 --http-health-path '/hc'"
     ) do |cli|
       expect(cli).to have_output_line(

--- a/spec/integrations/grpc/cli/options_spec.rb
+++ b/spec/integrations/grpc/cli/options_spec.rb
@@ -24,7 +24,7 @@ describe "gRPC CLI options", :cli do
         "--rpc-host 0.0.0.0:50053 -r ../spec/dummies/app.rb " \
         "--rpc-pool-size 10 --rpc-max-waiting-requests 2 " \
         "--rpc-poll-period 0.2 --rpc-pool-keep-alive 0.5 " \
-        "--redis-channel _test_cable_ --debug "
+        "--redis_channel _test_cable_ --debug "
       ) do |cli|
         expect(cli).to have_output_line("RPC server is listening on 0.0.0.0:50053")
         expect(cli).to have_output_line("Broadcasting Redis channel: _test_cable_")


### PR DESCRIPTION
## Summary
This change ensures all libraries and associated documentation are using the same syntax for `redis` cli arguments.

Related: https://github.com/anycable/anycable-rails/pull/172

## Changes

- [ ] Change A

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated documentation

<!--

---

Add any additional information in the end of the description after a horizontal line

-->
