### PR TITLE
Validate Redis server TLS certificates by default, allow to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Validate Redis TLS connections by default. ([@Envek][])
+
+- Add `ANYCABLE_REDIS_TLS_VERIFY` setting to disable validation of Redis server TLS certificate. ([@Envek][])
+
 ## 1.2.4 (2022-08-10)
 
 - Add NATS pub/sub adapter. ([@palkan][])
@@ -131,3 +135,4 @@ See [Changelog](https://github.com/anycable/anycable/blob/0-6-stable/CHANGELOG.m
 [@sponomarev]: https://github.com/sponomarev
 [@bibendi]: https://github.com/bibendi
 [@smasry]: https://github.com/smasry
+[@Envek]: https://github.com/Envek

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,6 +45,10 @@ Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 
 Redis channel for broadcasting (default: `"__anycable__"`).
 
+**redis_tls_verify** (`ANYCABLE_REDIS_TLS_VERIFY`, `--redis-tls-verify`)
+
+Whether to validate Redis server TLS certificate if `rediss://` protocol is used (default: `true`)
+
 **log_level** (`ANYCABLE_LOG_LEVEL`, `--log-level`)
 
 Logging level (default: `"info"`).

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -28,6 +28,7 @@ module AnyCable
       redis_url: ENV.fetch("REDIS_URL", "redis://localhost:6379/5"),
       redis_sentinels: nil,
       redis_channel: "__anycable__",
+      redis_tls_verify: true,
 
       ### NATS options
       nats_servers: "nats://localhost:4222",
@@ -57,6 +58,7 @@ module AnyCable
       coerce_types(
         redis_sentinels: {type: nil, array: true},
         nats_servers: {type: nil, array: true},
+        redis_tls_verify: :boolean,
         nats_dont_randomize_servers: :boolean,
         debug: :boolean,
         version_check_enabled: :boolean
@@ -94,6 +96,7 @@ module AnyCable
           --redis-url=url                   Redis URL for pub/sub, default: REDIS_URL or "redis://localhost:6379/5"
           --redis-channel=name              Redis channel for broadcasting, default: "__anycable__"
           --redis-sentinels=<...hosts>      Redis Sentinel followers addresses (as a comma-separated list), default: nil
+          --redis-tls-verify=yes|no         Whether to perform server certificate check in case of rediss:// protocol. Default: yes
 
       NATS PUB/SUB
           --nats-servers=<...addresses>     NATS servers for pub/sub, default: "nats://localhost:4222"
@@ -119,7 +122,7 @@ module AnyCable
 
         params[:sentinels] = sentinels.map { |sentinel| parse_sentinel(sentinel) }
       end.tap do |params|
-        next unless redis_url.match?(/rediss:\/\//)
+        next unless redis_url.match?(/rediss:\/\//) && !redis_tls_verify?
 
         params[:ssl_params] = {verify_mode: OpenSSL::SSL::VERIFY_NONE}
       end

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -85,6 +85,16 @@ describe AnyCable::Config do
       around { |ex| with_env("ANYCABLE_REDIS_URL" => "rediss://localhost:6379/3", "ANYCABLE_REDIS_SENTINELS" => "", &ex) }
 
       specify do
+        expect(subject.to_redis_params).to eq(url: "rediss://localhost:6379/3")
+      end
+    end
+
+    context "with TLS and server certificate verification disabled" do
+      subject(:config) { described_class.new }
+
+      around { |ex| with_env("ANYCABLE_REDIS_URL" => "rediss://localhost:6379/3", "ANYCABLE_REDIS_SENTINELS" => "", "ANYCABLE_REDIS_TLS_VERIFY" => "no", &ex) }
+
+      specify do
         expect(subject.to_redis_params).to eq(
           url: "rediss://localhost:6379/3",
           ssl_params: {verify_mode: OpenSSL::SSL::VERIFY_NONE}


### PR DESCRIPTION

## Summary

Using `VERIFY_NONE` for encrypted connection to Redis is not secure as it allows for man-in-the-middle attack.

However, given how troublesome it may be to set up SSL certificates properly, sometimes it should be disabled. Hence a setting for this.

## Changes

 - Validate Redis TLS connections by default.

 - Add `ANYCABLE_REDIS_TLS_VERIFY` setting to disable validation of Redis server TLS certificate.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
