### PR TITLE
Setting default driver to ruby if not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Setting the redis driver to ruby specified. ([@smasry][])
+
 ## 1.2.5 (2022-12-01)
 
 - Add `ANYCABLE_REDIS_TLS_VERIFY` setting to disable validation of Redis server TLS certificate. ([@Envek][])

--- a/lib/anycable/broadcast_adapters/redis.rb
+++ b/lib/anycable/broadcast_adapters/redis.rb
@@ -30,7 +30,7 @@ module AnyCable
         **options
       )
         options = AnyCable.config.to_redis_params.merge(options)
-        options[:driver] = :ruby
+        options[:driver] ||= :ruby
         @redis_conn = ::Redis.new(**options)
         @channel = channel
       end

--- a/spec/anycable/broadcast_adapters/redis_spec.rb
+++ b/spec/anycable/broadcast_adapters/redis_spec.rb
@@ -33,6 +33,12 @@ describe AnyCable::BroadcastAdapters::Redis do
       .with(url: "redis://local.redis:123", driver: :ruby)
   end
 
+  it "allows for other drivers" do
+    described_class.new(driver: :memory)
+    expect(Redis).to have_received(:new)
+      .with(driver: :memory, url: anything)
+  end
+
   describe "#broadcast" do
     it "publish stream data to channel" do
       allow(redis_conn).to receive(:publish)


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## Summary

Fixes an issue in graphql-anycable that causes the tests to use the ruby driver rather than fakeredis.

By allowing this to be optionally set we can set the driver for the broadcast adapter

```
### 
# graphql-anycable/spec/spec_helper.rb
...
AnyCable.broadcast_adapter = [:redis, driver: :memory]
...
```

## Changes

- [ ] Conditionally set the driver if not already specified

### Checklist

- [X ] I've added tests for this change
- [X ] I've added a Changelog entry
- [ ] I've updated documentation

<!--

---

Add any additional information in the end of the description after a horizontal line

-->
