### PR TITLE
chore: fix sed syntax in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ gem/grpc-tools:
 
 build: gem/grpc-tools
 	grpc_tools_ruby_protoc -I ./protos --ruby_out=./lib/anycable/protos --grpc_out=./lib/anycable/grpc ./protos/rpc.proto
-	sed -i '' '/'rpc_pb'/d' ./lib/anycable/grpc/rpc_services_pb.rb
-	sed -i '' 's/module RPC/module GRPC/g' ./lib/anycable/grpc/rpc_services_pb.rb
-	sed -i '' 's/Anycable/AnyCable/g' ./lib/anycable/protos/*_pb.rb
-	sed -i '' 's/Anycable/AnyCable/g' ./lib/anycable/grpc/*_pb.rb
+	sed -i'' '/'rpc_pb'/d' ./lib/anycable/grpc/rpc_services_pb.rb
+	sed -i'' 's/module RPC/module GRPC/g' ./lib/anycable/grpc/rpc_services_pb.rb
+	sed -i'' 's/Anycable/AnyCable/g' ./lib/anycable/protos/*_pb.rb
+	sed -i'' 's/Anycable/AnyCable/g' ./lib/anycable/grpc/*_pb.rb
 	bundle exec rubocop -A ./lib/anycable/protos ./lib/anycable/grpc
 
 release:


### PR DESCRIPTION
## Summary

GNU sed does not allow space for `-i' switch.

    -i[SUFFIX], --in-place[=SUFFIX]

           edit files in place (makes backup if SUFFIX supplied)

Makefile should either use long version or supply argument without extra space. Otherwise it will treat command as filename, and simply won't work.

    $ sed --version
    sed (GNU sed) 4.8

    $ make
    grpc_tools_ruby_protoc -I ./protos --ruby_out=./lib/anycable/protos --grpc_out=./lib/anycable/grpc ./protos/rpc.proto
    sed -i "" "/'rpc_pb'/d" ./lib/anycable/grpc/rpc_services_pb.rb
    sed: can't read /'rpc_pb'/d: No such file or directory
    make: *** [Makefile:8: build] Error 2

## Changes

- [x] Removed spaces for `-i` switch in `Makefile`