### PR TITLE
Experimental: grpc_kit support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,25 +14,27 @@ jobs:
       BUNDLE_RETRY: 3
       BUNDLE_FORCE_RUBY_PLATFORM: 1
       CI: true
+      ANYWAY_CONFIG_VERSION: ${{ matrix.anyway_config }}
+      ANYCABLE_GRPC_IMPL: ${{ matrix.grpc_impl }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0"]
+        ruby: ["3.0", "3.1", "3.2"]
         anyway_config: ["~> 2.2"]
+        grpc_impl: ["grpc"]
         include:
         - ruby: "3.1"
-          anyway_config: "~> 2.2"
-        - ruby: "3.2"
+          grpc_impl: "grpc_kit"
           anyway_config: "~> 2.2"
         - ruby: "2.7"
           anyway_config: "~> 2.1"
+          grpc_imlp: "grpc"
         - ruby: "2.6"
           anyway_config: "~> 2.1"
+          grpc_imlp: "grpc"
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
-      env:
-        ANYWAY_CONFIG_VERSION: ${{ matrix.anyway_config }}
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- (_Experimental_) Add support for [grpc_kit](https://github.com/cookpad/grpc_kit) as an alternative gRPC implementation. ([@palkan][])
+
+Add `grpc_kit` to your Gemfile and specify `ANYCABLE_GRPC_IMPL=grpc_kit` env var to use it.
+
 - Setting the redis driver to ruby specified. ([@smasry][])
 
 - Add mutual TLS support for connections to Redis. ([@Envek][])

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "activesupport", "~> 6.0"
 
 gem "anyway_config", ENV.fetch("ANYWAY_CONFIG_VERSION", ">= 2.1.0")
 gem "grpc", "~> 1.37" unless ENV["GRPC"] == "false"
+gem "grpc_kit" if ENV["ANYCABLE_GRPC_IMPL"] == "grpc_kit"
 
 eval_gemfile "gemfiles/rubocop.gemfile"
 eval_gemfile "gemfiles/rbs.gemfile"

--- a/Steepfile
+++ b/Steepfile
@@ -11,6 +11,8 @@ target :lib do
   ignore "lib/anycable/rspec/*.rb"
   ignore "lib/anycable/grpc/rpc_services_pb.rb"
   ignore "lib/anycable/protos/*.rb"
+  # TODO: unignore
+  ignore "lib/anycable/grpc_kit/*.rb"
 
   ignore "lib/anycable/cli.rb"
 

--- a/benchmarks/grpc/README.md
+++ b/benchmarks/grpc/README.md
@@ -22,3 +22,48 @@ k6 run echo.js --duration 10s
 # Run 30 connections for 30s
 k6 run echo.js --duration 30s --vus 30
 ```
+
+## Results
+
+### 2022-02-03
+
+
+Running `k6 run echo.js --duration=10s  --vus=30`:
+
+- gRPC
+
+```
+running (10.1s), 00/30 VUs, 300 complete and 0 interrupted iterations
+default ✓ [======================================] 30 VUs  10s
+
+     ✓ status is OK
+
+     checks...............: 100.00% ✓ 300       ✗ 0   
+     data_received........: 101 kB  10 kB/s
+     data_sent............: 97 kB   9.6 kB/s
+     grpc_req_duration....: avg=6.74ms min=1.18ms med=6.49ms max=18.95ms p(90)=10.88ms p(95)=12.11ms
+     iteration_duration...: avg=1s     min=1s     med=1s     max=1.02s   p(90)=1.01s   p(95)=1.01s  
+     iterations...........: 300     29.695843/s
+     vus..................: 30      min=30      max=30
+     vus_max..............: 30      min=30      max=30
+```
+
+- grpc_kit
+
+```
+running (10.1s), 00/30 VUs, 300 complete and 0 interrupted iterations
+default ✓ [======================================] 30 VUs  10s
+
+     ✓ status is OK
+
+     checks...............: 100.00% ✓ 300       ✗ 0
+     data_received........: 58 kB   5.7 kB/s
+     data_sent............: 92 kB   9.1 kB/s
+     grpc_req_duration....: avg=967.66µs min=446.91µs med=864.79µs max=5.82ms p(90)=1.37ms p(95)=1.58ms
+     iteration_duration...: avg=1s       min=1s       med=1s       max=1.02s  p(90)=1.01s  p(95)=1.01s 
+     iterations...........: 300     29.687503/s
+     vus..................: 30      min=30      max=30
+     vus_max..............: 30      min=30      max=30
+```
+
+`grpc_kit` performs much better for simple requests (p85: 1.5ms < 12ms).

--- a/benchmarks/grpc/server.rb
+++ b/benchmarks/grpc/server.rb
@@ -7,6 +7,8 @@ begin
   gemfile(retried, quiet: true) do
     source "https://rubygems.org"
 
+    gem "grpc_kit" if ENV["ANYCABLE_GRPC_IMPL"] == "grpc_kit"
+
     gem "anycable", path: "../.."
 
     gem "actioncable"

--- a/lib/anycable.rb
+++ b/lib/anycable.rb
@@ -109,11 +109,23 @@ module AnyCable
   end
 end
 
-# gRPC is the default for now, so, let's try to load it.
-begin
-  require "anycable/grpc"
-rescue LoadError => e
-  # Re-raise an exception if we failed to load grpc .so files
-  # (e.g., on Alpine Linux)
-  raise if /(error loading shared library|incompatible architecture)/i.match?(e.message)
+# Try loading a gRPC implementation
+impl = ENV.fetch("ANYCABLE_GRPC_IMPL", "grpc")
+
+case impl
+when "grpc"
+  begin
+    require "grpc/version"
+    require "anycable/grpc"
+  rescue LoadError => e
+    # Re-raise an exception if we failed to load grpc .so files
+    # (e.g., on Alpine Linux)
+    raise if /(error loading shared library|incompatible architecture)/i.match?(e.message)
+  end
+when "grpc_kit"
+  begin
+    require "grpc_kit/version"
+    require "anycable/grpc_kit"
+  rescue LoadError
+  end
 end

--- a/lib/anycable/grpc/config.rb
+++ b/lib/anycable/grpc/config.rb
@@ -3,12 +3,10 @@
 AnyCable::Config.attr_config(
   ### gRPC options
   rpc_host: "127.0.0.1:50051",
-  # For defaults see https://github.com/grpc/grpc/blob/51f0d35509bcdaba572d422c4f856208162022de/src/ruby/lib/grpc/generic/rpc_server.rb#L186-L216
-  rpc_pool_size: ::GRPC::RpcServer::DEFAULT_POOL_SIZE,
-  rpc_max_waiting_requests: ::GRPC::RpcServer::DEFAULT_MAX_WAITING_REQUESTS,
-  rpc_poll_period: ::GRPC::RpcServer::DEFAULT_POLL_PERIOD,
-  rpc_pool_keep_alive: ::GRPC::Pool::DEFAULT_KEEP_ALIVE,
-  # https://github.com/grpc/grpc/blob/f526602bff029b8db50a8d57134d72da33d8a752/include/grpc/impl/codegen/grpc_types.h#L141-L351
+  rpc_pool_size: 30,
+  rpc_max_waiting_requests: 20,
+  rpc_poll_period: 1,
+  rpc_pool_keep_alive: 0.25,
   rpc_server_args: {},
   log_grpc: false
 )

--- a/lib/anycable/grpc_kit.rb
+++ b/lib/anycable/grpc_kit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "grpc_kit"
+
+module AnyCable
+  module GRPC
+  end
+end
+
+require "anycable/grpc/config"
+require "anycable/grpc_kit/server"
+
+AnyCable.server_builder = ->(config) {
+  AnyCable.logger.info "gRPC Kit version: #{::GrpcKit::VERSION}"
+
+  ::GrpcKit.loglevel = :fatal
+  ::GrpcKit.logger = AnyCable.logger if config.log_grpc?
+
+  params = config.to_grpc_params
+
+  AnyCable::GRPC::Server.new(**params, host: config.rpc_host)
+}

--- a/lib/anycable/grpc_kit/server.rb
+++ b/lib/anycable/grpc_kit/server.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "anycable/grpc/handler"
+
+module AnyCable
+  module GRPC
+    raise LoadError, "AnyCable::GRPC::Server has been already loaded!" if defined?(AnyCable::GRPC::Server)
+
+    using(Module.new do
+      refine ::GrpcKit::Server do
+        attr_reader :max_pool_size
+
+        def stopped?
+          @stopping
+        end
+      end
+    end)
+
+    # Wrapper over gRPC kit server.
+    #
+    # Basic example:
+    #
+    #   # create new server listening on the loopback interface with 50051 port
+    #   server = AnyCable::GrpcKit::Server.new(host: "127.0.0.1:50051")
+    #
+    #   # run gRPC server in bakground
+    #   server.start
+    #
+    #   # stop server
+    #   server.stop
+    class Server
+      attr_reader :grpc_server, :host, :hostname, :port, :sock
+
+      def initialize(host:, logger: nil, **options)
+        @logger = logger
+        @host = host
+
+        host_parts = host.match(/\A(?<hostname>.+):(?<port>\d{2,5})\z/)
+
+        @hostname = host_parts[:hostname]
+        @port = host_parts[:port].to_i
+
+        @grpc_server = build_server(**options)
+      end
+
+      # Start gRPC server in background and
+      # wait untill it ready to accept connections
+      def start
+        return if running?
+
+        raise "Cannot re-start stopped server" if stopped?
+
+        logger.info "RPC server (grpc_kit) is starting..."
+
+        @sock = TCPServer.new(hostname, port)
+
+        server = grpc_server
+
+        @start_thread = Thread.new do
+          loop do
+            conn = @sock.accept
+            server.run(conn)
+          rescue IOError
+            # ignore broken connections
+          end
+        end
+
+        wait_till_running
+
+        logger.info "RPC server is listening on #{host} (workers_num: #{grpc_server.max_pool_size})"
+      end
+
+      def wait_till_running
+        raise "Server is not running" unless running?
+
+        timeout = 5
+
+        loop do
+          sock = TCPSocket.new(hostname, port, connect_timeout: 1)
+          stub = AnyCable::GRPC::Stub.new(sock)
+          stub.connect(AnyCable::ConnectionRequest.new(env: {}))
+          sock.close
+          break
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, SocketError
+          timeout -= 1
+          raise "Server is not responding" if timeout.zero?
+        end
+      end
+
+      def wait_till_terminated
+        raise "Server is not running" unless running?
+
+        start_thread.join
+      end
+
+      # Stop gRPC server if it's running
+      def stop
+        return unless running?
+
+        return if stopped?
+
+        grpc_server.graceful_shutdown
+        sock.close
+
+        logger.info "RPC server stopped"
+      end
+
+      def running?
+        !!sock
+      end
+
+      def stopped?
+        grpc_server.stopped?
+      end
+
+      private
+
+      attr_reader :start_thread
+
+      def logger
+        @logger ||= AnyCable.logger
+      end
+
+      def build_server(**options)
+        pool_size = options[:pool_size]
+
+        ::GrpcKit::Server.new(min_pool_size: pool_size, max_pool_size: pool_size).tap do |server|
+          server.handle(AnyCable::GRPC::Handler)
+        end
+      end
+    end
+  end
+end

--- a/sig/anycable/grpc/config.rbs
+++ b/sig/anycable/grpc/config.rbs
@@ -7,10 +7,10 @@ module AnyCable
       def rpc_pool_size=: (Integer) -> void
       def rpc_max_waiting_requests: () -> Integer
       def rpc_max_waiting_requests=: (Integer) -> void
-      def rpc_poll_period: () -> Integer
-      def rpc_poll_period=: (Integer) -> void
-      def rpc_pool_keep_alive: () -> Integer
-      def rpc_pool_keep_alive=: (Integer) -> void
+      def rpc_poll_period: () -> Numeric
+      def rpc_poll_period=: (Numeric) -> void
+      def rpc_pool_keep_alive: () -> Numeric
+      def rpc_pool_keep_alive=: (Numeric) -> void
       def rpc_server_args: () -> Hash[Symbol | String, untyped]?
       def rpc_server_args=: (Hash[Symbol | String, untyped]) -> void
       def log_grpc: () -> bool
@@ -24,8 +24,8 @@ module AnyCable
       def to_grpc_params: () -> {
         pool_size: Integer,
         max_waiting_requests: Integer,
-        poll_period: Integer,
-        pool_keep_alive: Integer,
+        poll_period: Numeric,
+        pool_keep_alive: Numeric,
         server_args: Hash[String, untyped]
       }
 

--- a/spec/integrations/grpc/cli/options_spec.rb
+++ b/spec/integrations/grpc/cli/options_spec.rb
@@ -29,7 +29,11 @@ describe "gRPC CLI options", :cli do
         expect(cli).to have_output_line("RPC server is listening on 0.0.0.0:50053")
         expect(cli).to have_output_line("Broadcasting Redis channel: _test_cable_")
         # GRPC logging
-        expect(cli).to have_output_line("handling /anycable.RPC/Connect with")
+        if GRPC_KIT
+          expect(cli).to have_output_line("Launched grpc_kit")
+        else
+          expect(cli).to have_output_line("handling /anycable.RPC/Connect with")
+        end
       end
     end
   end

--- a/spec/integrations/grpc/health_check_spec.rb
+++ b/spec/integrations/grpc/health_check_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "health checker" do
+describe "health checker", skip: GRPC_KIT do
   include_context "anycable:grpc:server"
 
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,11 @@ require "anycable"
 
 # Whether to run tests without GRPC loaded
 NO_GRPC = !defined?(::GRPC)
+GRPC_KIT = ENV["ANYCABLE_GRPC_IMPL"] == "grpc_kit"
+
+if GRPC_KIT
+  $stdout.puts "⚠️ Testing against grpc_kit"
+end
 
 require "json"
 require "rack"

--- a/spec/support/with_grpc_stub.rb
+++ b/spec/support/with_grpc_stub.rb
@@ -4,8 +4,26 @@ RSpec.shared_context "anycable:grpc:stub" do
   include_context "rpc_command"
 
   before(:all) do
-    @service = AnyCable::GRPC::Stub.new(AnyCable.config.rpc_host, :this_channel_is_insecure)
+    @service =
+      if GRPC_KIT
+        sock = TCPSocket.new(*AnyCable.config.rpc_host.split(":"))
+        AnyCable::GRPC::Stub.new(sock)
+      else
+        AnyCable::GRPC::Stub.new(AnyCable.config.rpc_host, :this_channel_is_insecure)
+      end
+    # ignore failed connections
+    # (happens when using grpc_kit and launching server after setting up a service)
+  rescue Errno::ECONNREFUSED
   end
 
-  let(:service) { @service }
+  let(:service) do
+    @service || begin
+      if GRPC_KIT
+        sock = TCPSocket.new(*AnyCable.config.rpc_host.split(":"))
+        AnyCable::GRPC::Stub.new(sock)
+      else
+        AnyCable::GRPC::Stub.new(AnyCable.config.rpc_host, :this_channel_is_insecure)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Make it possible to use [grpc_kit](https://github.com/cookpad/grpc_kit) as a gRPC server implementation.

Add `grpc_kit` to your Gemfile and specify `ANYCABLE_GRPC_IMPL=grpc_kit` env var to use it.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation

## Benchmarks

Running `k6 run echo.js --duration=10s  --vus=30`:

- gRPC

```
running (10.1s), 00/30 VUs, 300 complete and 0 interrupted iterations
default ✓ [======================================] 30 VUs  10s

     ✓ status is OK

     checks...............: 100.00% ✓ 300       ✗ 0   
     data_received........: 101 kB  10 kB/s
     data_sent............: 97 kB   9.6 kB/s
     grpc_req_duration....: avg=6.74ms min=1.18ms med=6.49ms max=18.95ms p(90)=10.88ms p(95)=12.11ms
     iteration_duration...: avg=1s     min=1s     med=1s     max=1.02s   p(90)=1.01s   p(95)=1.01s  
     iterations...........: 300     29.695843/s
     vus..................: 30      min=30      max=30
     vus_max..............: 30      min=30      max=30
```

- grpc_kit

```
running (10.1s), 00/30 VUs, 300 complete and 0 interrupted iterations
default ✓ [======================================] 30 VUs  10s

     ✓ status is OK

     checks...............: 100.00% ✓ 300       ✗ 0   
     data_received........: 58 kB   5.7 kB/s
     data_sent............: 92 kB   9.1 kB/s
     grpc_req_duration....: avg=967.66µs min=446.91µs med=864.79µs max=5.82ms p(90)=1.37ms p(95)=1.58ms
     iteration_duration...: avg=1s       min=1s       med=1s       max=1.02s  p(90)=1.01s  p(95)=1.01s 
     iterations...........: 300     29.687503/s
     vus..................: 30      min=30      max=30
     vus_max..............: 30      min=30      max=30
```

`grpc_kit` performs much better for simple requests (p85: 1.5ms < 12ms).