### PR TITLE
Minor improvements for `grpc_kit` altrernative

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,12 @@ gem "benchmark_driver"
 gem "activesupport", "~> 6.0"
 
 gem "anyway_config", ENV.fetch("ANYWAY_CONFIG_VERSION", ">= 2.1.0")
-gem "grpc", "~> 1.37" unless ENV["GRPC"] == "false"
-gem "grpc_kit" if ENV["ANYCABLE_GRPC_IMPL"] == "grpc_kit"
+unless ENV["GRPC"] == "false"
+  case ENV["ANYCABLE_GRPC_IMPL"]
+  when "grpc_kit" then gem "grpc_kit"
+  else gem "grpc", "~> 1.37"
+  end
+end
 
 eval_gemfile "gemfiles/rubocop.gemfile"
 eval_gemfile "gemfiles/rbs.gemfile"

--- a/benchmarks/grpc/server.rb
+++ b/benchmarks/grpc/server.rb
@@ -7,7 +7,10 @@ begin
   gemfile(retried, quiet: true) do
     source "https://rubygems.org"
 
-    gem "grpc_kit" if ENV["ANYCABLE_GRPC_IMPL"] == "grpc_kit"
+    case ENV["ANYCABLE_GRPC_IMPL"]
+    when "grpc_kit" then gem "grpc_kit"
+    else gem "grpc"
+    end
 
     gem "anycable", path: "../.."
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,10 @@ Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will b
 
 [Broadcast adapter](./broadcast_adapters.md) to use. Available options out-of-the-box: `redis` (default), `nats`, `http`.
 
+**grpc_impl** (`ANYCABLE_GRPC_IMPL`, `--grpc-impl`)
+
+An implementation of the gRPC server (supported: `"google_grpc"` for the [official gem](https://github.com/grpc/grpc/tree/master/src/ruby) (default), `"grpc_kit"` for the [alternative implementation](https://github.com/cookpad/grpc_kit)).
+
 **nats_servers** (`ANYCABLE_NATS_SERVERS`, `--nats-servers`)
 
 A comma-separated list of NATS server addresses (default: `"nats://localhost:4222"`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,10 +29,6 @@ Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will b
 
 [Broadcast adapter](./broadcast_adapters.md) to use. Available options out-of-the-box: `redis` (default), `nats`, `http`.
 
-**grpc_impl** (`ANYCABLE_GRPC_IMPL`, `--grpc-impl`)
-
-An implementation of the gRPC server (supported: `"google_grpc"` for the [official gem](https://github.com/grpc/grpc/tree/master/src/ruby) (default), `"grpc_kit"` for the [alternative implementation](https://github.com/cookpad/grpc_kit)).
-
 **nats_servers** (`ANYCABLE_NATS_SERVERS`, `--nats-servers`)
 
 A comma-separated list of NATS server addresses (default: `"nats://localhost:4222"`).


### PR DESCRIPTION
## Summary

Minor updates of the experimental feature (usage of `grpc_kit` as an altrenative to the official `grpc`)

## Changes

- [ ] Fix the dependencies for the experimental feature, namely
  - [ ] don't add the dependency from `grpc` if the `grpc_kit` is chosen
  - [ ] don't add the dependency from any library if `ANYCABLE_GRPC` env is set to false
  - [ ] add versioning for the `grpc_kit` library.

- [ ] Add documentation for the experimental option.

### Checklist

- ~~[ ] I've added tests for this change~~ (NA)
- ~~[ ] I've added a Changelog entry~~ (NA)
- [x] I've updated documentation