### PR TITLE
typo: usage example in redis.rb

### DIFF
--- a/lib/anycable/broadcast_adapters/redis.rb
+++ b/lib/anycable/broadcast_adapters/redis.rb
@@ -21,7 +21,7 @@ module AnyCable
     #
     # You can override these params:
     #
-    #   AnyCable.broadcast_adapter = :redis, url: "redis://my_redis", channel: "_any_cable_"
+    #   AnyCable.broadcast_adapter = :redis, { url: "redis://my_redis", channel: "_any_cable_" }
     class Redis < Base
       attr_reader :redis_conn, :channel
 


### PR DESCRIPTION
The code below in the comment example
`AnyCable.broadcast_adapter = :redis, url: "redis://my_redis", channel: "_any_cable_"`
raises an error
`SyntaxError: unexpected label`.

I added squares {} to fix it.