### PR TITLE
Redisx adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- Add `redisx` broadcast adapter. ([@palkan][])
+
+A next-gen (Broker-compatible) broadcasting adapter using Redis Streams.
+
 ## 1.3.1 (2023-05-12)
 
 - Fix gRPC health check response for an empty service. ([@palkan][])

--- a/docs/broadcast_adapters.md
+++ b/docs/broadcast_adapters.md
@@ -12,7 +12,7 @@ AnyCable ships with three broadcast adapters by default: Redis (default), [NATS]
 
 HTTP adapter has zero-dependencies and, thus, allows you to quickly start using AnyCable.
 
-Since v1.4, HTTP adapter can also be considered for production (thanks to the new [pub/sub component](/anycable-go/pubsub.md) in AnyCable-Go). Moreover, currently, it's the only adapter compatible with the new [broker feature](/anycable-go/broker.md) of AnyCable-Go.
+Since v1.4, HTTP adapter can also be considered for production (thanks to the new [pub/sub component](/anycable-go/pubsub.md) in AnyCable-Go). Moreover, it can be used with the new [broker feature](/anycable-go/broker.md) of AnyCable-Go.
 
 To use HTTP adapter specify `broadcast_adapter` configuration parameter (`--broadcast-adapter=http` or `ANYCABLE_BROADCAST_ADAPTER=http` or set in the code/YML) and make sure your AnyCable WebSocket server supports it. An URL to broadcast to could be specified via `http_broadcast_url` parameter (defaults to `http://localhost:8080/_broadcast`, which corresponds to the [AnyCable-Go](../anycable-go/getting_started.md#configuration-parameters) default).
 
@@ -32,9 +32,15 @@ You must configure both Ruby RPC server and a WebSocket server to use the same `
 
 ## Redis X
 
-<p class="pro-badge-header"></p>
+Redis X adapter uses [Redis Streams][redis-streams] instead of Publish/Subscribe to deliver broadcasting messages from your application to WebSocket servers. That gives us the following benefits:
 
-Coming soon ⏳
+- **Better delivery guarantees**. Even if there is no WebSocket server available at the broadcast time, the message will be stored in Redis and delivered to the server once it is available. In combination with the [broker feature](/anycable-go/broker.md), you can achieve at-least-once delivery guarantees (compared to at-most-once provided by Redis pub/sub).
+
+- **Broker compatibility**. Using a [broker](/anycable-go/broker.md) (or **streams history**) requires handling each broadcasted message by a single node in the cluster (so it can be _registered_ in a cache). With Redis X adapter, we achieve this by using consumer groups for the Redis stream.
+
+Configuration options are the same as for the Redis adapter. The `redis_channel` option is treated as a stream name.
+
+See [configuration](./configuration.md) for available Redis options.
 
 ## Redis adapter (legacy)
 
@@ -81,3 +87,4 @@ Want to have a different adapter out-of-the-box? Join [the discussion](https://g
 
 [NATS]: https://nats.io
 [nats-pure]: https://github.com/nats-io/nats-pure.rb
+[redis-streams]: https://redis.io/docs/data-types/streams-tutorial/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 
 **redis_channel** (`ANYCABLE_REDIS_CHANNEL`, `--redis-channel`)
 
-Redis channel for broadcasting (default: `"__anycable__"`).
+Redis channel for broadcasting (default: `"__anycable__"`). When using the `redisx` adapter, it's used as a name of the Redis stream.
 
 **redis_tls_verify** (`ANYCABLE_REDIS_TLS_VERIFY`, `--redis-tls-verify`)
 

--- a/forspell.dict
+++ b/forspell.dict
@@ -24,3 +24,4 @@ liveness
 Kubernetes
 Balancer
 Twilio
+broadcasted

--- a/lib/anycable/broadcast_adapters/redisx.rb
+++ b/lib/anycable/broadcast_adapters/redisx.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "anycable/broadcast_adapters/redis"
+
+module AnyCable
+  module BroadcastAdapters
+    # Next-gen Redis adapter for broadcasting over Redis streams.
+    #
+    # Unlike Redis adapter, RedisX adapter delivers each broadcast message only
+    # to a single WS server, which is responsible for re-broadcasting it within the cluster.
+    # It's required for the Broker (hot streams cache) support.
+    #
+    # Example:
+    #
+    #   AnyCable.broadcast_adapter = :redisx
+    #
+    # It uses Redis configuration from global AnyCable config
+    # by default.
+    # NOTE: The `redis_channel` config param is used as a stream name.
+    #
+    # You can override these params:
+    #
+    #   AnyCable.broadcast_adapter = :redisx, { url: "redis://my_redis", stream_name: "_any_cable_" }
+    class Redisx < Redis
+      def raw_broadcast(payload)
+        redis_conn.xadd(channel, {payload: payload})
+      end
+
+      def announce!
+        logger.info "Broadcasting Redis stream: #{channel}"
+      end
+    end
+  end
+end

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -27,7 +27,7 @@ module AnyCable
       broadcast_adapter: :redis,
 
       ### Redis options
-      redis_url: ENV.fetch("REDIS_URL", "redis://localhost:6379/5"),
+      redis_url: ENV.fetch("REDIS_URL", "redis://localhost:6379"),
       redis_sentinels: nil,
       redis_channel: "__anycable__",
       redis_tls_verify: false,

--- a/sig/anycable/broadcast_adapters/redisx.rbs
+++ b/sig/anycable/broadcast_adapters/redisx.rbs
@@ -1,0 +1,6 @@
+module AnyCable
+  module BroadcastAdapters
+    class Redisx < Redis
+    end
+  end
+end

--- a/spec/anycable/broadcast_adapters/http_spec.rb
+++ b/spec/anycable/broadcast_adapters/http_spec.rb
@@ -26,6 +26,20 @@ describe AnyCable::BroadcastAdapters::Http do
     expect(adapter.headers).to eq("Authorization" => "Bearer tshhh")
   end
 
+  describe "#announce" do
+    around do |ex|
+      old_logger = AnyCable.logger
+      AnyCable.remove_instance_variable(:@logger)
+      ex.run
+      AnyCable.logger = old_logger
+      AnyCable.config.reload
+    end
+
+    specify do
+      expect { described_class.new.announce! }.to output(%r{Broadcasting HTTP url: http://ws.example.com/_broadcast}).to_stdout_from_any_process
+    end
+  end
+
   describe "#broadcast" do
     let(:adapter) { described_class.new(url: "http://ws.example.com:8090/_broadcast") }
 

--- a/spec/anycable/broadcast_adapters/nats_spec.rb
+++ b/spec/anycable/broadcast_adapters/nats_spec.rb
@@ -36,6 +36,20 @@ describe AnyCable::BroadcastAdapters::Nats do
       .with(nil, {servers: ["nats://natsy:8222", "nats://nasty:2228"], dont_randomize_servers: true})
   end
 
+  describe "#announce" do
+    around do |ex|
+      old_logger = AnyCable.logger
+      AnyCable.remove_instance_variable(:@logger)
+      ex.run
+      AnyCable.logger = old_logger
+      AnyCable.config.reload
+    end
+
+    specify do
+      expect { described_class.new.announce! }.to output(/Broadcasting NATS channel: _test_/).to_stdout_from_any_process
+    end
+  end
+
   describe "#broadcast" do
     it "publish stream data to channel" do
       allow(nats_conn).to receive(:publish)

--- a/spec/anycable/broadcast_adapters/redis_spec.rb
+++ b/spec/anycable/broadcast_adapters/redis_spec.rb
@@ -39,6 +39,20 @@ describe AnyCable::BroadcastAdapters::Redis do
       .with(driver: :memory, url: anything)
   end
 
+  describe "#announce" do
+    around do |ex|
+      old_logger = AnyCable.logger
+      AnyCable.remove_instance_variable(:@logger)
+      ex.run
+      AnyCable.logger = old_logger
+      AnyCable.config.reload
+    end
+
+    specify do
+      expect { described_class.new.announce! }.to output(/Broadcasting Redis channel: _test_/).to_stdout_from_any_process
+    end
+  end
+
   describe "#broadcast" do
     it "publish stream data to channel" do
       allow(redis_conn).to receive(:publish)

--- a/spec/anycable/broadcast_adapters/redisx_spec.rb
+++ b/spec/anycable/broadcast_adapters/redisx_spec.rb
@@ -19,6 +19,20 @@ describe AnyCable::BroadcastAdapters::Redisx do
 
   let(:config) { AnyCable.config }
 
+  describe "#announce" do
+    around do |ex|
+      old_logger = AnyCable.logger
+      AnyCable.remove_instance_variable(:@logger)
+      ex.run
+      AnyCable.logger = old_logger
+      AnyCable.config.reload
+    end
+
+    specify do
+      expect { described_class.new.announce! }.to output(/Broadcasting Redis stream: _test_/).to_stdout_from_any_process
+    end
+  end
+
   describe "#broadcast" do
     it "add new entry to stream" do
       allow(redis_conn).to receive(:xadd)

--- a/spec/anycable/broadcast_adapters/redisx_spec.rb
+++ b/spec/anycable/broadcast_adapters/redisx_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "anycable/broadcast_adapters/redisx"
+
+describe AnyCable::BroadcastAdapters::Redisx do
+  let(:redis_conn) { double("redis_conn") }
+
+  before do
+    config.redis_url = "redis://redis-1:6478"
+    config.redis_channel = "_test_"
+    config.redis_sentinels = nil
+
+    allow(::Redis).to receive(:new) { redis_conn }
+  end
+
+  after { AnyCable.config.reload }
+
+  let(:config) { AnyCable.config }
+
+  describe "#broadcast" do
+    it "add new entry to stream" do
+      allow(redis_conn).to receive(:xadd)
+
+      adapter = described_class.new
+      adapter.broadcast("notification", "hello!")
+
+      expect(redis_conn).to have_received(:xadd).with(
+        "_test_",
+        {payload: {stream: "notification", data: "hello!"}.to_json}
+      )
+    end
+  end
+end

--- a/spec/anycable/config_spec.rb
+++ b/spec/anycable/config_spec.rb
@@ -144,7 +144,7 @@ describe AnyCable::Config do
     around { |ex| with_env("ANYCABLE_CONF" => nil, &ex) }
 
     describe "#redis_url" do
-      specify { expect(config.redis_url).to eq("redis://localhost:6379/5") }
+      specify { expect(config.redis_url).to eq("redis://localhost:6379") }
     end
   end
 


### PR DESCRIPTION
## Summary

Redis X is a new broadcast adapter built on top of Redis Streams. It's primary purpose is to provide Broker (streams history) compatibility and also better delivery guarantees. See the docs updates for more.

## Changes

- [x] Added `redisx` broadcasting adapter
- [x] Changed default Redis URL from `localhost:6379/5` to `localhost:6379`—Redis Streams are database-aware (unlike pub/sub) 

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

