### PR TITLE
FEAT: RPC over HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add HTTP RPC support. ([@palkan][])
+
 ## 1.4.0.rc.1 (2023-06-01)
 
 - Add `redisx` broadcast adapter. ([@palkan][])

--- a/benchmarks/rails/connect_subscribe.js
+++ b/benchmarks/rails/connect_subscribe.js
@@ -1,0 +1,84 @@
+// Build k6 with xk6-cable like this:
+//    xk6 build v0.38.3 --with github.com/anycable/xk6-cable@v0.3.0
+
+import { check, sleep, fail } from "k6";
+import cable from "k6/x/cable";
+import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.1.0/index.js";
+
+const rampingOptions = {
+  scenarios: {
+    default: {
+      executor: "ramping-vus",
+      startVUs: 100,
+      stages: [
+        { duration: "10s", target: 300 },
+        { duration: "20s", target: 500 },
+        { duration: "30s", target: 1000 },
+        { duration: "60s", target: 1000 },
+        { duration: "120s", target: 0 },
+      ],
+      gracefulStop: "5m",
+      gracefulRampDown: "5m",
+    },
+  },
+};
+
+export const options = __ENV.SKIP_OPTIONS ? {} : rampingOptions;
+
+let config = __ENV;
+
+config.URL = config.URL || "ws://localhost:8080/cable";
+
+let url = config.URL;
+let channelName = config.CHANNEL || "BenchmarkChannel";
+let streamsNum = (config.STREAMS || "50") | 0;
+let streamId = __VU % streamsNum;
+let iterations = (config.N || "100") | 0;
+
+export default function () {
+  let cableOptions = {
+    receiveTimeoutMs: 15000,
+  };
+
+  // Prevent from creating a lot of connections at once
+  sleep(randomIntBetween(5, 10) / 10);
+
+  let client = cable.connect(url, cableOptions);
+
+  if (
+    !check(client, {
+      "successful connection": (obj) => obj,
+    })
+  ) {
+    fail("connection failed");
+  }
+
+  let channel = client.subscribe(channelName, { id: streamId });
+
+  if (
+    !check(channel, {
+      "successful subscription": (obj) => obj,
+    })
+  ) {
+    fail("failed to subscribe");
+  }
+
+  for (let i = 0; ; i++) {
+    // Sampling
+    if (randomIntBetween(1, 10) / 10 <= 0.3) {
+      channel.perform("broadcast", {
+        content: `hello from ${__VU} numero ${i + 1}`,
+      });
+    }
+
+    sleep(randomIntBetween(5, 10) / 100);
+
+    let incoming = channel.receiveAll(0.2);
+
+    sleep(randomIntBetween(5, 10) / 100);
+
+    if (i > iterations) break;
+  }
+
+  client.disconnect();
+}

--- a/docs/http_rpc.md
+++ b/docs/http_rpc.md
@@ -1,0 +1,45 @@
+# RPC over HTTP
+
+AnyCable supports RPC communication between a WebSocket server and your web application over HTTP (JSON). Although the default gRPC communication is more performant and, thus, preferred, it comes with a price of additional infrastructure complexity—you have to manage a separate process/service.
+
+HTTP RPC is a good alternative if you don't want to deal with gRPC or you are using a platform that doesn't support gRPC (e.g., Heroku, Google Cloud Run).
+
+You can embed AnyCable HTTP RPC _server_ (a Rack application) into your Ruby or Rails application's web server (e.g., Puma) and serve AnyCable RPC requests from the same process.
+
+## Using with Rails
+
+To enable HTTP RPC in your Rails application, you must configure the `http_rpc_mount_path` parameter. For example, in your `config/anycable.yml`:
+
+```yml
+development:
+  http_rpc_mount_path: "/_anycable"
+
+production:
+  http_rpc_mount_path: "/__some_other_anycable_path"
+```
+
+That's it! Now configure your WebSocket to perform RPC over HTTP at your mount path (e.g., `/_anycable`).
+
+## Security
+
+You can (and MUST in production) protect your HTTP RPC server with basic token-based authorization. To do so, you need to set the `http_rpc_secret` parameter (in YAML or via the `ANYCABLE_HTTP_RPC_SECRET` environment variable). Don't forget to set the same value in your WebSocket server configuration.
+
+## Considerations
+
+- **Performance**. HTTP/1 has a higher overhead than HTTP/2 used by gRPC, so you should expect a higher latency and lower throughput. Keep this in mind when choosing between HTTP RPC and gRPC.
+
+- **Shared web server resources**. Rails applications have a limited HTTP concurrency (based on the total number of threads used by a web server, such as Puma), serving both regular HTTP requests and AnyCable RPC requests can result into a race for shared resources, and, in the worst case, longer request queuing times for user-facing HTTP operations.
+
+- **Scalability**. It's not possible to scale AnyCable RPC requests separately from the main web application. If you need to scale AnyCable RPC requests independently, you should use gRPC.
+
+## Using with Rack
+
+You can mount AnyCable HTTP RPC server into your Rack application using the Rack Builder interface:
+
+```ruby
+Rack::Builder.new do
+  map "/anycable" do
+    run AnyCable::HTTPRC::Server.new
+  end
+end
+```

--- a/lib/anycable.rb
+++ b/lib/anycable.rb
@@ -16,6 +16,8 @@ require "anycable/socket"
 require "anycable/rpc"
 require "anycable/health_server"
 
+require "anycable/httrpc/server"
+
 # AnyCable allows to use any websocket service (written in any language) as a replacement
 # for ActionCable server.
 #

--- a/lib/anycable/config.rb
+++ b/lib/anycable/config.rb
@@ -53,6 +53,9 @@ module AnyCable
       http_health_port: nil,
       http_health_path: "/health",
 
+      ### HTTP RPC options
+      http_rpc_secret: nil,
+
       ### Misc options
       version_check_enabled: true,
       sid_header_enabled: true
@@ -110,6 +113,9 @@ module AnyCable
       HTTP PUB/SUB
           --http-broadcast-url              HTTP pub/sub endpoint URL, default: "http://localhost:8090/_broadcast"
           --http-broadcast-secret           HTTP pub/sub authorization secret, default: <none> (disabled)
+
+      HTTP RPC
+          --http-rpc-secret                 HTTP RPC authorization secret, default: <none> (disabled)
     TXT
 
     # Build Redis parameters

--- a/lib/anycable/httrpc/server.rb
+++ b/lib/anycable/httrpc/server.rb
@@ -36,7 +36,7 @@ module AnyCable
 
         response = AnyCable.rpc_handler.handle(rpc_command, payload, build_meta(env))
 
-        [200, {}, [response.to_json]]
+        [200, {}, [response.to_json({format_enums_as_integers: true})]]
       rescue JSON::ParserError, ArgumentError => e
         [422, {}, ["Invalid request body: #{e.message}"]]
       end

--- a/lib/anycable/httrpc/server.rb
+++ b/lib/anycable/httrpc/server.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module AnyCable
+  module HTTRPC
+    class Server
+      def initialize(token: AnyCable.config.http_rpc_secret)
+        @token = token
+      end
+
+      def call(env)
+        if env["REQUEST_METHOD"] != "POST"
+          return [404, {}, ["Not found"]]
+        end
+
+        if token && env["HTTP_AUTHORIZATION"] != "Bearer #{token}"
+          return [401, {}, ["Unauthorized"]]
+        end
+
+        rpc_command = env["PATH_INFO"].sub(%r{^/}, "").to_sym
+
+        # check if command is supported and return 404 if not
+        return [404, {}, ["Not found"]] unless AnyCable.rpc_handler.supported?(rpc_command)
+
+        # read request body and it's empty, return 422
+        request_body = env["rack.input"].read
+        return [422, {}, ["Empty request body"]] if request_body.empty?
+
+        payload =
+          case rpc_command
+          when :connect then AnyCable::ConnectionRequest.decode_json(request_body)
+          when :disconnect then AnyCable::DisconnectRequest.decode_json(request_body)
+          when :command then AnyCable::CommandMessage.decode_json(request_body)
+          end
+
+        return [422, {}, ["Invalid request body"]] if payload.nil?
+
+        response = AnyCable.rpc_handler.handle(rpc_command, payload, build_meta(env))
+
+        [200, {}, [response.to_json]]
+      rescue JSON::ParserError, ArgumentError => e
+        [422, {}, ["Invalid request body: #{e.message}"]]
+      end
+
+      private
+
+      attr_reader :token
+
+      def build_meta(env)
+        # `x-anycable-meta-var` -> `meta["var"]`
+        env.each_with_object({}) do |(k, v), meta|
+          next unless k.start_with?("HTTP_X_ANYCABLE_META_")
+          meta[k.sub(%r{^HTTP_X_ANYCABLE_META_}, "").downcase] = v
+          meta
+        end
+      end
+    end
+  end
+end

--- a/lib/anycable/rpc/handler.rb
+++ b/lib/anycable/rpc/handler.rb
@@ -23,6 +23,10 @@ module AnyCable
         end
       end
 
+      def supported?(cmd)
+        %i[connect disconnect command].include?(cmd)
+      end
+
       private
 
       attr_reader :commands, :middleware

--- a/sig/anycable/config.rbs
+++ b/sig/anycable/config.rbs
@@ -41,6 +41,8 @@ module AnyCable
     def http_health_port=: (Integer) -> void
     def http_health_path: () -> String
     def http_health_path=: (String) -> void
+    def http_rpc_secret: () -> String
+    def http_rpc_secret=: (String) -> void
     def version_check_enabled: () -> bool
     def version_check_enabled=: (bool) -> void
     def version_check_enabled?: () -> bool

--- a/sig/anycable/httrpc/server.rbs
+++ b/sig/anycable/httrpc/server.rbs
@@ -1,0 +1,11 @@
+module AnyCable
+  module HTTRPC
+    class Server
+      def initialize: (?token: String?) -> void
+      def call: (Hash[String, untyped] env) -> [Integer, Hash[String, String], Array[String]]
+      private
+      attr_reader token: String?
+      def build_meta: (Hash[String, untyped] env) -> Hash[String, String]
+    end
+  end
+end

--- a/sig/anycable/rpc.rbs
+++ b/sig/anycable/rpc.rbs
@@ -96,6 +96,7 @@ module AnyCable
     ) -> void
 
     def to_h: () -> Hash[Symbol, untyped]
+    def to_json: (?Hash[Symbol, untyped] options) -> String
   end
 
   class CommandMessage
@@ -142,6 +143,7 @@ module AnyCable
     ) -> void
 
     def to_h: () -> Hash[Symbol, untyped]
+    def to_json: (?Hash[Symbol, untyped] options) -> String
   end
 
   class DisconnectRequest
@@ -164,6 +166,7 @@ module AnyCable
 
     %a{rbs:test:skip} def initialize: (status: rpcStatus, ?error_msg: String) -> void
     def to_h: () -> Hash[Symbol, untyped]
+    def to_json: (?Hash[Symbol, untyped] options) -> String
   end
 
   type rpcRequest = ConnectionRequest | DisconnectRequest | CommandMessage

--- a/sig/anycable/rpc.rbs
+++ b/sig/anycable/rpc.rbs
@@ -73,6 +73,7 @@ module AnyCable
   class ConnectionRequest
     include _WithEnv
 
+    def self.decode_json: (String) -> instance
     %a{rbs:test:skip} def initialize: (?env: Env) -> void
     def to_h: () -> Hash[Symbol, untyped]
   end
@@ -99,6 +100,8 @@ module AnyCable
 
   class CommandMessage
     include _WithEnv
+
+    def self.decode_json: (String) -> instance
 
     attr_accessor command: String
     attr_accessor identifier: String
@@ -143,6 +146,8 @@ module AnyCable
 
   class DisconnectRequest
     include _WithEnv
+
+    def self.decode_json: (String) -> instance
 
     attr_accessor identifiers: String
     attr_accessor subscriptions: Array[String]

--- a/sig/anycable/rpc/handler.rbs
+++ b/sig/anycable/rpc/handler.rbs
@@ -15,6 +15,7 @@ module AnyCable
 
       def initialize: (?middleware: MiddlewareChain) -> void
       def handle: (Symbol cmd, rpcRequest data, ?rpcMetadata meta) -> rpcResponse
+      def supported?: (Symbol cmd) -> bool
 
       private
 

--- a/spec/integrations/http_rpc_server_spec.rb
+++ b/spec/integrations/http_rpc_server_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "HTTP RPC" do
+  include_context "rpc_command"
+
+  let(:server) { AnyCable::HTTRPC::Server.new }
+
+  def post(path, request, headers = {})
+    env = Rack::MockRequest.env_for(File.join("http://localhost:3000", path), method: "POST")
+    env["rack.input"] = StringIO.new(request.to_json)
+
+    headers.each { |k, v| env["HTTP_#{k.upcase.tr("-", "_")}"] = v }
+
+    server.call(env).then do |response|
+      response = Rack::Response.new(response[2], response[0], response[1])
+      raise "Unexpected result: #{response.code} #{response}" unless response.ok?
+      response.body.first
+    end
+  end
+
+  describe "bad requests" do
+    it "not a POST request" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/connect", method: "GET")
+      expect(server.call(env)).to eq [404, {}, ["Not found"]]
+    end
+
+    it "missing body" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/connect", method: "POST")
+      expect(server.call(env)).to eq [422, {}, ["Empty request body"]]
+    end
+
+    it "uknown command" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/unknown", method: "POST")
+      env["rack.input"] = StringIO.new({}.to_json)
+
+      expect(server.call(env)).to eq [404, {}, ["Not found"]]
+    end
+  end
+
+  describe "authentication" do
+    let(:server) { AnyCable::HTTRPC::Server.new(token: "secret") }
+
+    it "missing token" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/connect", method: "POST")
+
+      expect(server.call(env)).to eq [401, {}, ["Unauthorized"]]
+    end
+
+    it "invalid token" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/connect", method: "POST")
+      env["HTTP_AUTHORIZATION"] = "Bearer not-a-secret"
+
+      expect(server.call(env)).to eq [401, {}, ["Unauthorized"]]
+    end
+
+    it "valid token" do
+      env = Rack::MockRequest.env_for("http://localhost:3000/connect", method: "POST")
+      env["HTTP_AUTHORIZATION"] = "Bearer secret"
+
+      # we passed authentication check
+      expect(server.call(env)).to eq [422, {}, ["Empty request body"]]
+    end
+  end
+
+  describe "CONNECT" do
+    let(:headers) do
+      {
+        "Cookie" => "username=john;"
+      }
+    end
+    let(:url) { "http://example.io/cable?token=123" }
+
+    let(:request_headers) { {} }
+    let(:request) { AnyCable::ConnectionRequest.new(env: env) }
+
+    let(:response) { post "/connect", request, request_headers }
+
+    subject(:result) do
+      AnyCable::ConnectionResponse.decode_json(response)
+    end
+
+    it "responds with success", :aggregate_failures do
+      expect(subject).to be_success
+      identifiers = JSON.parse(subject.identifiers)
+      expect(identifiers).to include(
+        "current_user" => "john",
+        "path" => "/cable",
+        "token" => "123"
+      )
+      expect(subject.transmissions.first).to eq JSON.dump("type" => "welcome")
+    end
+
+    it "invokes Connect handler" do
+      allow(AnyCable.rpc_handler).to receive(:handle).and_call_original
+
+      expect(subject).to be_success
+      expect(AnyCable.rpc_handler).to have_received(:handle).with(:connect, request, an_instance_of(Hash))
+    end
+
+    context "with meta headers" do
+      let(:request_headers) do
+        {
+          "X-AnyCable-Meta-Sid" => "20230629"
+        }
+      end
+
+      it "passes meta headers to the handler" do
+        allow(AnyCable.rpc_handler).to receive(:handle).and_call_original
+
+        expect(subject).to be_success
+        expect(AnyCable.rpc_handler)
+          .to have_received(:handle).with(:connect, request, {"sid" => "20230629"})
+      end
+    end
+
+    context "when exception" do
+      let(:url) { "http://example.io/cable?raise=sudden_connect_error" }
+
+      it "responds with ERROR", :aggregate_failures do
+        expect(subject).to be_error
+        expect(subject.error_msg).to eq("sudden_connect_error")
+      end
+
+      it "notifies exception handler" do
+        subject
+
+        expect(TestExHandler.last_error).to have_attributes(
+          exception: have_attributes(message: "sudden_connect_error"),
+          method: "connect",
+          message: request.to_h
+        )
+      end
+    end
+  end
+
+  describe "DISCONNECT" do
+    let(:user) { "disco" }
+    let(:url) { "http://example.io/cable_lite?token=123" }
+    let(:subscriptions) { %w[a b] }
+    let(:headers) { {"Cookie" => "username=jack;"} }
+
+    let(:request) do
+      AnyCable::DisconnectRequest.new(
+        identifiers: identifiers.to_json,
+        subscriptions: subscriptions,
+        env: env
+      )
+    end
+
+    let(:log) { AnyCable::TestFactory.events_log }
+
+    let(:response) { post "/disconnect", request }
+
+    subject(:result) do
+      AnyCable::DisconnectResponse.decode_json(response)
+    end
+
+    it "invokes #disconnect method with correct data" do
+      expect { subject }.to change { log.size }.by(1)
+
+      expect(log.last[:data]).to eq(name: "disco", path: "/cable_lite", subscriptions: %w[a b])
+    end
+
+    it "invokes Disconnect handler" do
+      allow(AnyCable.rpc_handler).to receive(:handle).and_call_original
+
+      expect(subject).to be_success
+      expect(AnyCable.rpc_handler).to have_received(:handle).with(:disconnect, request, an_instance_of(Hash))
+    end
+  end
+
+  describe "COMMAND" do
+    let(:channel_id) { "echo" }
+    let(:command) { "message" }
+    let(:data) { {action: "echo", data: 3} }
+
+    let(:response) { post "/command", request }
+
+    subject(:result) { AnyCable::CommandResponse.decode_json(response) }
+
+    it "responds with result" do
+      expect(subject).to be_success
+      expect(subject.transmissions.size).to eq 1
+      expect(subject.transmissions.first).to include({"result" => {"data" => 3}}.to_json)
+    end
+
+    it "invokes Command handler" do
+      allow(AnyCable.rpc_handler).to receive(:handle).and_call_original
+
+      expect(subject).to be_success
+      expect(AnyCable.rpc_handler).to have_received(:handle).with(:command, request, an_instance_of(Hash))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR brings RPC over HTTP support.

## Changes

- [x] Added Rack-compatible RPC server implementation which can be embedded into a web server

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

