### PR TITLE
Allow to receive TLS gRPC connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add TLS support for gRPC server. ([@Envek][])
+
 ## 1.4.0 (2023-07-07)
 
 - Add HTTP RPC support. ([@palkan][])

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,10 @@ Here is the list of the most commonly used configuration parameters and the way 
 
 Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will be changed to `"127.0.0.1:50051"` in future versions).
 
+**rpc_tls_cert** (`ANYCABLE_RPC_TLS_CERT`, `--rpc-tls-cert`) and **rpc_tls_key** (`ANYCABLE_RPC_TLS_KEY`, `--rpc-tls-key`)
+
+Specify file paths or contents for TLS certificate and private key for gRPC server.
+
 **broadcast_adapter** (`ANYCABLE_BROADCAST_ADAPTER`, `--broadcast-adapter`)
 
 [Broadcast adapter](./broadcast_adapters.md) to use. Available options out-of-the-box: `redis` (default), `nats`, `http`.

--- a/lib/anycable/grpc/config.rb
+++ b/lib/anycable/grpc/config.rb
@@ -34,7 +34,7 @@ module AnyCable
           max_waiting_requests: rpc_max_waiting_requests,
           poll_period: rpc_poll_period,
           pool_keep_alive: rpc_pool_keep_alive,
-          server_credentials: server_credentials,
+          tls_credentials: tls_credentials,
           server_args: enhance_grpc_server_args(normalized_grpc_server_args)
         }
       end
@@ -57,15 +57,15 @@ module AnyCable
         opts
       end
 
-      def server_credentials
+      def tls_credentials
         cert_path_or_content = rpc_tls_cert # Assign to local variable to make steep happy
         key_path_or_content = rpc_tls_key # Assign to local variable to make steep happy
-        return :this_port_is_insecure if cert_path_or_content.nil? || key_path_or_content.nil?
+        return {} if cert_path_or_content.nil? || key_path_or_content.nil?
 
         cert = File.exist?(cert_path_or_content) ? File.read(cert_path_or_content) : cert_path_or_content
         pkey = File.exist?(key_path_or_content) ? File.read(key_path_or_content) : key_path_or_content
 
-        ::GRPC::Core::ServerCredentials.new(nil, [{private_key: pkey, cert_chain: cert}], false)
+        {cert: cert, pkey: pkey}
       end
     end
   end

--- a/lib/anycable/grpc/config.rb
+++ b/lib/anycable/grpc/config.rb
@@ -58,10 +58,12 @@ module AnyCable
       end
 
       def server_credentials
-        return :this_port_is_insecure unless rpc_tls_cert && rpc_tls_key
+        cert_path_or_content = rpc_tls_cert # Assign to local variable to make steep happy
+        key_path_or_content = rpc_tls_key # Assign to local variable to make steep happy
+        return :this_port_is_insecure if cert_path_or_content.nil? || key_path_or_content.nil?
 
-        cert = File.exist?(rpc_tls_cert) ? File.read(rpc_tls_cert) : rpc_tls_cert
-        pkey = File.exist?(rpc_tls_key) ? File.read(rpc_tls_key) : rpc_tls_key
+        cert = File.exist?(cert_path_or_content) ? File.read(cert_path_or_content) : cert_path_or_content
+        pkey = File.exist?(key_path_or_content) ? File.read(key_path_or_content) : key_path_or_content
 
         ::GRPC::Core::ServerCredentials.new(nil, [{private_key: pkey, cert_chain: cert}], false)
       end

--- a/lib/anycable/grpc/server.rb
+++ b/lib/anycable/grpc/server.rb
@@ -83,9 +83,9 @@ module AnyCable
       end
 
       def build_server(**options)
-        server_credentials = options.delete(:server_credentials)
+        tls_credentials = options.delete(:tls_credentials)
         ::GRPC::RpcServer.new(**options).tap do |server|
-          server.add_http2_port(host, server_credentials)
+          server.add_http2_port(host, server_credentials(**tls_credentials))
           server.handle(AnyCable::GRPC::Handler)
           server.handle(build_health_checker)
         end
@@ -102,6 +102,12 @@ module AnyCable
           Grpc::Health::V1::HealthCheckResponse::ServingStatus::SERVING
         )
         health_checker
+      end
+
+      def server_credentials(cert: nil, pkey: nil)
+        return :this_port_is_insecure if cert.nil? || pkey.nil?
+
+        ::GRPC::Core::ServerCredentials.new(nil, [{private_key: pkey, cert_chain: cert}], false)
       end
     end
   end

--- a/lib/anycable/grpc/server.rb
+++ b/lib/anycable/grpc/server.rb
@@ -82,9 +82,9 @@ module AnyCable
         @logger ||= AnyCable.logger
       end
 
-      def build_server(**options)
+      def build_server(server_credentials:, **options)
         ::GRPC::RpcServer.new(**options).tap do |server|
-          server.add_http2_port(host, :this_port_is_insecure)
+          server.add_http2_port(host, server_credentials)
           server.handle(AnyCable::GRPC::Handler)
           server.handle(build_health_checker)
         end

--- a/lib/anycable/grpc/server.rb
+++ b/lib/anycable/grpc/server.rb
@@ -82,7 +82,8 @@ module AnyCable
         @logger ||= AnyCable.logger
       end
 
-      def build_server(server_credentials:, **options)
+      def build_server(**options)
+        server_credentials = options.delete(:server_credentials)
         ::GRPC::RpcServer.new(**options).tap do |server|
           server.add_http2_port(host, server_credentials)
           server.handle(AnyCable::GRPC::Handler)

--- a/sig/anycable/grpc/config.rbs
+++ b/sig/anycable/grpc/config.rbs
@@ -32,13 +32,13 @@ module AnyCable
         max_waiting_requests: Integer,
         poll_period: Numeric,
         pool_keep_alive: Numeric,
-        server_credentials: ::GRPC::Core::ServerCredentials | :this_port_is_insecure,
+        tls_credentials: Hash[Symbol, String],
         server_args: Hash[String, untyped]
       }
 
       def normalized_grpc_server_args: () -> Hash[String, untyped]
       def enhance_grpc_server_args: (Hash[String, untyped]) -> Hash[String, untyped]
-      def server_credentials: () -> (::GRPC::Core::ServerCredentials | :this_port_is_insecure)
+      def tls_credentials: () -> Hash[Symbol, String]
     end
   end
 end

--- a/sig/anycable/grpc/config.rbs
+++ b/sig/anycable/grpc/config.rbs
@@ -3,6 +3,10 @@ module AnyCable
     interface _Config
       def rpc_host: () -> String
       def rpc_host=: (String) -> void
+      def rpc_tls_cert: () -> String?
+      def rpc_tls_cert=: (String?) -> void
+      def rpc_tls_key: () -> String?
+      def rpc_tls_key=: (String?) -> void
       def rpc_pool_size: () -> Integer
       def rpc_pool_size=: (Integer) -> void
       def rpc_max_waiting_requests: () -> Integer
@@ -28,11 +32,13 @@ module AnyCable
         max_waiting_requests: Integer,
         poll_period: Numeric,
         pool_keep_alive: Numeric,
+        server_credentials: ::GRPC::Core::ServerCredentials | :this_port_is_insecure,
         server_args: Hash[String, untyped]
       }
 
       def normalized_grpc_server_args: () -> Hash[String, untyped]
       def enhance_grpc_server_args: (Hash[String, untyped]) -> Hash[String, untyped]
+      def server_credentials: () -> (::GRPC::Core::ServerCredentials | :this_port_is_insecure)
     end
   end
 end

--- a/sig/anycable/grpc/server.rbs
+++ b/sig/anycable/grpc/server.rbs
@@ -15,7 +15,7 @@ module AnyCable
       def logger: () -> Logger
       def build_server: (**untyped options) -> untyped
       def build_health_checker: () -> untyped
-      def server_credentials: () -> (::GRPC::Core::ServerCredentials | :this_port_is_insecure)
+      def server_credentials: (?cert: String?, ?pkey: String?) -> (::GRPC::Core::ServerCredentials | :this_port_is_insecure)
     end
   end
 end

--- a/sig/anycable/grpc/server.rbs
+++ b/sig/anycable/grpc/server.rbs
@@ -15,6 +15,7 @@ module AnyCable
       def logger: () -> Logger
       def build_server: (**untyped options) -> untyped
       def build_health_checker: () -> untyped
+      def server_credentials: () -> (::GRPC::Core::ServerCredentials | :this_port_is_insecure)
     end
   end
 end

--- a/sig/vendor/grpc.rbs
+++ b/sig/vendor/grpc.rbs
@@ -109,6 +109,15 @@ module GRPC
 
     SIGNAL_CHECK_PERIOD: Float
   end
+
+  module Core
+    class ServerCredentials
+
+      private
+
+      def initialize: (untyped, Array[Hash[Symbol, String]], bool) -> void
+    end
+  end
 end
 
 # module Google

--- a/spec/anycable/grpc/config_spec.rb
+++ b/spec/anycable/grpc/config_spec.rb
@@ -56,4 +56,24 @@ describe AnyCable::Config do
         .to eq({"grpc.max_connection_age_ms" => 60_000})
     end
   end
+
+  describe "#server_credentials" do
+    subject :server_credentials do
+      described_class.new.server_credentials
+    end
+
+    it "returns insecure config if rpc_tls_cert and rpc_tls_key are not set" do
+      expect(server_credentials).to eq :this_port_is_insecure
+    end
+
+    context "when rpc_tls_cert and rpc_tls_key are set" do
+      around do |ex|
+        with_env("ANYCABLE_RPC_TLS_CERT" => "BASE64ABRACADABRA", "ANYCABLE_RPC_TLS_KEY" => "BASE64ABRACADABRA", &ex)
+      end
+
+      it "returns TLS-enabled config" do
+        expect(server_credentials).to be_a GRPC::Core::ServerCredentials
+      end
+    end
+  end
 end

--- a/spec/anycable/grpc/config_spec.rb
+++ b/spec/anycable/grpc/config_spec.rb
@@ -57,22 +57,25 @@ describe AnyCable::Config do
     end
   end
 
-  describe "#server_credentials" do
-    subject :server_credentials do
-      described_class.new.server_credentials
+  describe "#tls_credentials" do
+    subject :tls_credentials do
+      described_class.new.tls_credentials
     end
 
     it "returns insecure config if rpc_tls_cert and rpc_tls_key are not set" do
-      expect(server_credentials).to eq :this_port_is_insecure
+      expect(tls_credentials).to be_empty
     end
 
     context "when rpc_tls_cert and rpc_tls_key are set" do
+      let(:cert) { "BASE64ABRACADABRA1" }
+      let(:pkey)  { "BASE64ABRACADABRA2" }
+
       around do |ex|
-        with_env("ANYCABLE_RPC_TLS_CERT" => "BASE64ABRACADABRA", "ANYCABLE_RPC_TLS_KEY" => "BASE64ABRACADABRA", &ex)
+        with_env("ANYCABLE_RPC_TLS_CERT" => cert, "ANYCABLE_RPC_TLS_KEY" => pkey, &ex)
       end
 
       it "returns TLS-enabled config" do
-        expect(server_credentials).to be_a GRPC::Core::ServerCredentials
+        expect(tls_credentials).to include(cert: cert, pkey: pkey)
       end
     end
   end

--- a/spec/anycable/grpc/config_spec.rb
+++ b/spec/anycable/grpc/config_spec.rb
@@ -68,7 +68,7 @@ describe AnyCable::Config do
 
     context "when rpc_tls_cert and rpc_tls_key are set" do
       let(:cert) { "BASE64ABRACADABRA1" }
-      let(:pkey)  { "BASE64ABRACADABRA2" }
+      let(:pkey) { "BASE64ABRACADABRA2" }
 
       around do |ex|
         with_env("ANYCABLE_RPC_TLS_CERT" => cert, "ANYCABLE_RPC_TLS_KEY" => pkey, &ex)


### PR DESCRIPTION
## Summary

Resolves https://github.com/anycable/anycable-go/issues/180

## Changes

- [x] Allow to configure TLS gRPC

### Checklist

- [ ] I've added tests for this change (not sure how to test)
- [x] I've added a Changelog entry
- [x] I've updated documentation

---

Recommended usage:

 1. Specify certificate and private key file paths in the `rpc-tls-cert` and `rpc-tls-key` command line options:

    ```sh
    bundle exec anycable --rpc-tls-cert /path/to/server/cert.pem --rpc-tls-key /path/to/server/cert.key
    ```

 2. Specify CA cert contents directly in the `ANYCABLE_RPC_TLS_CERT` and `ANYCABLE_RPC_TLS_KEY` env variables:

    ```sh
    ANYCABLE_RPC_TLS_CERT="$(cat /path/to/server/cert.pem)" ANYCABLE_RPC_TLS_KEY="$(cat /path/to/server/cert.key)" bundle exec anycable
    ```