### PR TITLE
Broadcast options (exclude_socket)

### DIFF
--- a/docs/broadcast_adapters.md
+++ b/docs/broadcast_adapters.md
@@ -46,6 +46,18 @@ AnyCable.broadcast_adapter.batching do
 end #=> the current batch is published
 ```
 
+### Broadcast options
+
+Since v1.4.5, AnyCable supports additional broadcast options. You can pass them as the third argument to the `AnyCable.broadcast` method:
+
+```ruby
+AnyCable.broadcast("my_stream", {text: "hoi"}, {exclude_socket: "some-socket-id"})
+```
+
+The following options are supported:
+
+- `exclude_socket`: pass an AnyCable socket ID to exclude it from the broadcast recipients list. Useful if you want to broadcast to all clients except the one that initiated the broadcast.
+
 ## HTTP adapter
 
 HTTP adapter has zero-dependencies and, thus, allows you to quickly start using AnyCable.

--- a/lib/anycable.rb
+++ b/lib/anycable.rb
@@ -92,8 +92,8 @@ module AnyCable
 
     # Raw broadcast message to the channel, sends only string!
     # To send hash or object use ActionCable.server.broadcast instead!
-    def broadcast(channel, payload)
-      broadcast_adapter.broadcast(channel, payload)
+    def broadcast(...)
+      broadcast_adapter.broadcast(...)
     end
 
     def rpc_handler

--- a/lib/anycable/broadcast_adapters/base.rb
+++ b/lib/anycable/broadcast_adapters/base.rb
@@ -26,11 +26,11 @@ module AnyCable
         Thread.current[:anycable_batching]&.last
       end
 
-      def broadcast(stream, payload)
+      def broadcast(stream, payload, options = nil)
         if batching?
-          current_batch << {stream: stream, data: payload}
+          current_batch << {stream: stream, data: payload, meta: options}.compact
         else
-          raw_broadcast({stream: stream, data: payload}.to_json)
+          raw_broadcast({stream: stream, data: payload, meta: options}.compact.to_json)
         end
       end
 

--- a/sig/anycable.rbs
+++ b/sig/anycable.rbs
@@ -36,6 +36,6 @@ module AnyCable
   def self.server_callbacks: () -> Array[^() -> void]
   def self.broadcast_adapter: () -> _BroadcastAdapter
   def self.broadcast_adapter=: (untyped adapter) -> void
-  def self.broadcast: (String channel, String payload) -> void
+  def self.broadcast: (String channel, String payload, ?broadcastOptions options) -> void
   def self.rpc_handler: () -> RPC::Handler
 end

--- a/sig/anycable/broadcast_adapters/base.rbs
+++ b/sig/anycable/broadcast_adapters/base.rbs
@@ -1,11 +1,13 @@
 module AnyCable
+  type broadcastOptions = {exclude_socket: String}
+
   interface _BroadcastAdapter
     def raw_broadcast: (String _data) -> void
     def batching: (?bool enabled) { () -> untyped } -> untyped
     def start_batching: () -> void
     def finish_batching: () -> void
     def batching?: () -> (bool | NilClass)
-    def broadcast: (String stream, String payload) -> void
+    def broadcast: (String stream, String payload, ?broadcastOptions options) -> void
     def broadcast_command: (String command, **untyped payload) -> void
     def announce!: () -> void
   end

--- a/spec/anycable/broadcast_adapters/base_spec.rb
+++ b/spec/anycable/broadcast_adapters/base_spec.rb
@@ -107,4 +107,14 @@ describe AnyCable::BroadcastAdapters::Base do
       )
     end
   end
+
+  context "with options" do
+    it "adds options to the payload as metadata" do
+      subject.broadcast("test", "a", exclude_socket: "123")
+
+      expect(subject.sent).to eq([
+        {stream: "test", data: "a", meta: {exclude_socket: "123"}}.to_json
+      ])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add support for adding metadata to broadcast messages (e.g., `exclude_socket` to avoid sending a message to a specific connection).

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation

