### PR TITLE
Rack 3.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: "gemfiles/rubocop.gemfile"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.1
@@ -43,7 +43,7 @@ jobs:
       matrix:
         ruby: ["3.2"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   rspec:
+    name: RSpec - Ruby ${{ matrix.ruby }} - ${{ matrix.grpc_impl }} - Rack ${{ matrix.rack }}
     if: ${{ !contains(github.event.head_commit.message, '[ci skip tests]') }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,19 +16,25 @@ jobs:
       BUNDLE_FORCE_RUBY_PLATFORM: 1
       CI: true
       ANYCABLE_GRPC_IMPL: ${{ matrix.grpc_impl }}
+      RACK_VERSION: ${{ matrix.rack }}
       COVERAGE: "true"
       COVERALLS_REPO_TOKEN: ${{ secrets.github_token }}
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
         anyway_config: ["~> 2.2"]
         grpc_impl: ["grpc"]
+        rack: ["~> 3.0"]
         include:
         - ruby: "3.1"
           grpc_impl: "grpc_kit"
         - ruby: "2.7"
           grpc_imlp: "grpc"
+        - ruby: "3.3"
+          rack: "~> 2.0"
+        - ruby: "3.3"
+          rack: "~> 3.0.0"
     steps:
     - run: |
         echo "Commit msg: ${{ github.event.head_commit.message }}"
@@ -45,7 +51,7 @@ jobs:
         bundle exec rspec
     - name: Coveralls upload
       run: |
-        ./coveralls -p --job-flag=ruby-${{ matrix.ruby }}-${{ matrix.grpc_impl }}
+        ./coveralls -p --job-flag=ruby-${{ matrix.ruby }}-${{ matrix.grpc_impl }}-${{ matrix.rack }}
     - name: Run RSpec w/o gRPC
       env:
         GRPC: false
@@ -53,7 +59,7 @@ jobs:
         bundle exec rspec
     - name: Coveralls upload
       run: |
-        ./coveralls -p --job-flag=ruby-${{ matrix.ruby }}-${{ matrix.grpc_impl }}-no-grpc
+        ./coveralls -p --job-flag=ruby-${{ matrix.ruby }}-${{ matrix.grpc_impl }}-no-grpc-${{ matrix.rack }}
     - name: Run RSpec with RBS runtime tester
       if: matrix.ruby == '3.1'
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - run: |
         echo "Commit msg: ${{ github.event.head_commit.message }}"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fixed compatibility with Rack 3.1 ([@earlopain][])
+
 ## 1.5.0 (2024-04-01)
 
 - Fixed gRPC keepalive settings to align with the Go server client. ([@palkan][])
@@ -211,3 +213,4 @@ See [Changelog](https://github.com/anycable/anycable/blob/0-6-stable/CHANGELOG.m
 [@smasry]: https://github.com/smasry
 [@Envek]: https://github.com/Envek
 [@cylon-v]: https://github.com/cylon-v
+[@earlopain]: https://github.com/earlopain

--- a/anycable-core.gemspec
+++ b/anycable-core.gemspec
@@ -36,7 +36,13 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency "rake", ">= 13.0"
-  spec.add_development_dependency "rack", "~> 2.0"
+
+  if ENV["RACK_VERSION"] && ENV["RACK_VERSION"] != ""
+    spec.add_development_dependency "rack", ENV["RACK_VERSION"]
+  else
+    spec.add_development_dependency "rack", "~> 3.0"
+  end
+
   spec.add_development_dependency "rspec", ">= 3.5"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-lcov"

--- a/lib/anycable/httrpc/server.rb
+++ b/lib/anycable/httrpc/server.rb
@@ -28,9 +28,8 @@ module AnyCable
 
         # read request body and it's empty, return 422
         # rack.input is optional starting in Rack 3.1
-        if !env["rack.input"] || (request_body = env["rack.input"].read).empty?
-          return [422, {}, ["Empty request body"]]
-        end
+        request_body = env["rack.input"]&.read
+        return [422, {}, ["Empty request body"]] if request_body.nil? || request_body.empty?
 
         payload =
           case rpc_command

--- a/lib/anycable/httrpc/server.rb
+++ b/lib/anycable/httrpc/server.rb
@@ -27,8 +27,10 @@ module AnyCable
         return [404, {}, ["Not found"]] unless AnyCable.rpc_handler.supported?(rpc_command)
 
         # read request body and it's empty, return 422
-        request_body = env["rack.input"].read
-        return [422, {}, ["Empty request body"]] if request_body.empty?
+        # rack.input is optional starting in Rack 3.1
+        if !env["rack.input"] || (request_body = env["rack.input"].read).empty?
+          return [422, {}, ["Empty request body"]]
+        end
 
         payload =
           case rpc_command

--- a/lib/anycable/socket.rb
+++ b/lib/anycable/socket.rb
@@ -154,7 +154,7 @@ module AnyCable
       # (not all of them though, just those enough for Action Cable to work)
       # See https://rubydoc.info/github/rack/rack/master/file/SPEC
       # and https://github.com/rack/rack/blob/master/lib/rack/lint.rb
-      {
+      env = {
         "REQUEST_METHOD" => "GET",
         "SCRIPT_NAME" => "",
         "PATH_INFO" => "/",
@@ -163,13 +163,16 @@ module AnyCable
         "SERVER_PORT" => "80",
         "rack.url_scheme" => "http",
         "rack.input" => StringIO.new("", "r").tap { |io| io.set_encoding(Encoding::ASCII_8BIT) },
-        "rack.version" => ::Rack::VERSION,
         "rack.errors" => StringIO.new("").tap { |io| io.set_encoding(Encoding::ASCII_8BIT) },
         "rack.multithread" => true,
         "rack.multiprocess" => false,
         "rack.run_once" => false,
         "rack.hijack?" => false
       }
+
+      # Rack 3.1 removes `Rack::VERSION`. rack.version is optional (deprecated) since Rack 3.0
+      env["rack.version"] = ::Rack::VERSION if ::Rack::RELEASE < "3.0"
+      env
     end
 
     def build_headers(headers)

--- a/lib/anycable/socket.rb
+++ b/lib/anycable/socket.rb
@@ -172,7 +172,11 @@ module AnyCable
       }
 
       # Rack 3.1 removes `Rack::VERSION`. rack.version is optional (deprecated) since Rack 3.0
-      env["rack.version"] = ::Rack::VERSION if ::Rack::RELEASE < "3.0"
+      if ::Rack::RELEASE < "3.0"
+        rversion = ::Rack::VERSION
+        # @type var rversion : String
+        env["rack.version"] = rversion
+      end
       env
     end
 

--- a/lib/anycable/socket.rb
+++ b/lib/anycable/socket.rb
@@ -161,6 +161,7 @@ module AnyCable
         "QUERY_STRING" => "",
         "SERVER_NAME" => "",
         "SERVER_PORT" => "80",
+        "SERVER_PROTOCOL" => "HTTP/1.1",
         "rack.url_scheme" => "http",
         "rack.input" => StringIO.new("", "r").tap { |io| io.set_encoding(Encoding::ASCII_8BIT) },
         "rack.errors" => StringIO.new("").tap { |io| io.set_encoding(Encoding::ASCII_8BIT) },

--- a/spec/anycable_spec.rb
+++ b/spec/anycable_spec.rb
@@ -42,7 +42,7 @@ describe AnyCable do
           @options = options
         end
 
-        def broadcast
+        def broadcast(...)
         end
       end
     end


### PR DESCRIPTION
## Summary

Closes #234

## Changes

* Rack 3.1 removes `Rack::VERSION`. `rack.version` is optional (i.e. deprecated) since Rack 3.0, so only set this for Rack 2.
* Rack 3.1 makes `rack.input` optional. So if some test doesn't set this in its mock response the server will receive `nil` for it. I'm not sure if this is actually a possible situation outside of tests but I've updated logic to handle this regardless.

I added tests against a few rack versions to validate these changes. There is still one spec violation remaining: `SERVER_PROTOCOL` is required in Rack >= 3. I'm not sure what this is supposed to be here so I left that alone. It's a lint failure only and seems to work fine regardless.

I'd appreciate if you could tell me more about this, or just add a commit to fix this yourself. CI tests fail because of this if you want to check it out.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation
