### PR TITLE
Session (internal) keepalive refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ Parse `--redis_url` (`ANYCABLE_REDIS_URL` or `REDIS_URL`) using the `rueidis` st
 
 - Added ability to require `pong` messages from clients (for better detection of broken connections). ([@palkan][])
 
-Use `--pong_timoout=<number of seconds to wait for ping>` option to enable this feature. **NOTE:** This option is only applied to clients using the extended Action Cable protocol.
+Use `--pong_timeout=<number of seconds to wait for ping>` option to enable this feature. **NOTE:** This option is only applied to clients using the extended Action Cable protocol.
 
 - Allow configuring ping interval and ping timestamp precision per connection. ([@palkan][])
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "colorize"
 gem "puma"
 
 gem "activesupport", "~> 7.0.0"
+# https://github.com/rails/rails/issues/54263
+gem "concurrent-ruby", "1.3.4"
 
 if File.directory?(File.join(__dir__, "../anycable-rb"))
   $stdout.puts "\n=== Using local gems for Anyt ===\n\n"

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -89,8 +89,8 @@ type Broker interface {
 	// Retrieves presence information for the stream (counts, records, etc. depending on the options)
 	PresenceInfo(stream string, opts ...PresenceInfoOption) (*common.PresenceInfo, error)
 
-	// Marks presence record as finished (for cache expiration)
-	FinishPresence(sid string) error
+	// Marks presence record as still alive
+	TouchPresence(sid string) error
 }
 
 // LocalBroker is a single-node broker that can used to store streams data locally
@@ -241,6 +241,6 @@ func (LegacyBroker) PresenceInfo(stream string, opts ...PresenceInfoOption) (*co
 	return nil, errors.New("presence not supported")
 }
 
-func (LegacyBroker) FinishPresence(sid string) error {
+func (LegacyBroker) TouchPresence(sid string) error {
 	return nil
 }

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -75,8 +75,8 @@ type Broker interface {
 	CommitSession(sid string, session Cacheable) error
 	// Fetches session's state from cache (by session id)
 	RestoreSession(from string) ([]byte, error)
-	// Marks session as finished (for cache expiration)
-	FinishSession(sid string) error
+	// Prevent session cache from expiration
+	TouchSession(sid string) error
 
 	// Adds a new presence record for the stream. Returns true if that's the first
 	// presence record for the presence ID (pid, a unique user presence identifier).
@@ -225,7 +225,7 @@ func (LegacyBroker) RestoreSession(from string) ([]byte, error) {
 	return nil, nil
 }
 
-func (LegacyBroker) FinishSession(sid string) error {
+func (LegacyBroker) TouchSession(sid string) error {
 	return nil
 }
 

--- a/broker/memory_test.go
+++ b/broker/memory_test.go
@@ -257,12 +257,27 @@ func TestMemory_expirePresence(t *testing.T) {
 
 	assert.Equal(t, 2, info.Total)
 
-	broker.FinishPresence("s1") // nolint: errcheck
-	broker.FinishPresence("s2") // nolint: errcheck
+	time.Sleep(500 * time.Millisecond)
+	broker.TouchPresence("s1") // nolint: errcheck
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(500 * time.Millisecond)
+	broker.TouchPresence("s1") // nolint: errcheck
 
-	broker.PresenceAdd("a", "s3", "user_1", "john") // nolint: errcheck
+	time.Sleep(500 * time.Millisecond)
+	broker.TouchPresence("s1") // nolint: errcheck
+
+	time.Sleep(500 * time.Millisecond)
+	broker.expire()
+
+	info, err = broker.PresenceInfo("a")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, info.Total)
+	assert.Equal(t, "user_1", info.Records[0].ID)
+
+	time.Sleep(1000 * time.Millisecond)
+
+	broker.PresenceAdd("a", "s3", "user_1", "jack") // nolint: errcheck
 
 	broker.expire()
 
@@ -271,4 +286,5 @@ func TestMemory_expirePresence(t *testing.T) {
 
 	assert.Equal(t, 1, info.Total)
 	assert.Equal(t, "user_1", info.Records[0].ID)
+	assert.Equal(t, "jack", info.Records[0].Info)
 }

--- a/broker/nats.go
+++ b/broker/nats.go
@@ -494,7 +494,7 @@ func (n *NATS) PresenceInfo(stream string, opts ...PresenceInfoOption) (*common.
 	return nil, errors.New("presence not supported")
 }
 
-func (n *NATS) FinishPresence(sid string) error {
+func (n *NATS) TouchPresence(sid string) error {
 	return nil
 }
 

--- a/broker/nats.go
+++ b/broker/nats.go
@@ -427,7 +427,7 @@ func (n *NATS) RestoreSession(sid string) ([]byte, error) {
 	return entry.Value(), nil
 }
 
-func (n *NATS) FinishSession(sid string) error {
+func (n *NATS) TouchSession(sid string) error {
 	err := n.Ready(jetstreamReadyTimeout)
 	if err != nil {
 		return err

--- a/broker/nats_test.go
+++ b/broker/nats_test.go
@@ -255,8 +255,18 @@ func TestNATSBroker_Sessions(t *testing.T) {
 	err = broker.CommitSession("test345", &TestCacheable{"cache-me-again"})
 	require.NoError(t, err)
 
-	err = broker.FinishSession("test345")
+	committed, err := anotherBroker.RestoreSession("test345")
+
 	require.NoError(t, err)
+	assert.Equal(t, []byte("cache-me-again"), committed)
+
+	// Expiration
+	time.Sleep(500 * time.Millisecond)
+
+	err = broker.TouchSession("test345")
+	require.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond)
 
 	finished, err := anotherBroker.RestoreSession("test345")
 
@@ -264,7 +274,7 @@ func TestNATSBroker_Sessions(t *testing.T) {
 	assert.Equal(t, []byte("cache-me-again"), finished)
 
 	// Expiration
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 
 	finishedStale, err := anotherBroker.RestoreSession("test345")
 	require.NoError(t, err)
@@ -323,7 +333,7 @@ func TestNATSBroker_SessionsTTLChange(t *testing.T) {
 	assert.Equalf(t, []byte("cache-me-again"), restored, "Expected to restore session data: %s", restored)
 
 	// Touch session
-	err = anotherBroker.FinishSession("test234")
+	err = anotherBroker.TouchSession("test234")
 	require.NoError(t, err)
 
 	time.Sleep(2 * time.Second)

--- a/cli/session_options.go
+++ b/cli/session_options.go
@@ -21,7 +21,14 @@ func (r *Runner) sessionOptionsFromProtocol(protocol string) []node.SessionOptio
 	opts := []node.SessionOption{}
 
 	if common.IsExtendedActionCableProtocol(protocol) {
-		opts = append(opts, node.WithResumable(true))
+		// configure session cache and presence keepalive intervals
+		// (must be slightly less than the corresponding TTLs)
+		opts = append(opts,
+			node.WithKeepaliveIntervals(
+				time.Duration(r.config.Broker.SessionsTTL*500)*time.Millisecond,
+				time.Duration(r.config.Broker.PresenceTTL*500)*time.Millisecond,
+			),
+		)
 
 		if r.config.App.PongTimeout > 0 {
 			opts = append(opts, node.WithPongTimeout(time.Duration(r.config.App.PongTimeout)*time.Second))

--- a/etc/anyt/presence_tests/perform_test.rb
+++ b/etc/anyt/presence_tests/perform_test.rb
@@ -23,11 +23,11 @@ feature "Presence" do
   end
 
   let(:client2) do
-    build_client(ignore: %w[ping welcome], qs: "test=presence_perform&user_id=2024")
+    build_client(ignore: %w[ping welcome], qs: "test=presence_perform&user_id=2024", protocol: "actioncable-v1-ext-json")
   end
 
   let(:client3) do
-    build_client(ignore: %w[ping welcome], qs: "test=presence_perform&user_id=2025")
+    build_client(ignore: %w[ping welcome], qs: "test=presence_perform&user_id=2025", protocol: "actioncable-v1-ext-json")
   end
 
   scenario %(

--- a/etc/anyt/presence_tests/subscribe_test.rb
+++ b/etc/anyt/presence_tests/subscribe_test.rb
@@ -41,15 +41,15 @@ feature "Presence" do
   end
 
   let(:client2) do
-    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2024&name=Bart")
+    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2024&name=Bart", protocol: "actioncable-v1-ext-json")
   end
 
   let(:client2_clone) do
-    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2024&name=Bart")
+    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2024&name=Bart", protocol: "actioncable-v1-ext-json")
   end
 
   let(:client3) do
-    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2025&name=Lisa")
+    build_client(ignore: %w[ping welcome], qs: "test=presence_subscribe&user_id=2025&name=Lisa", protocol: "actioncable-v1-ext-json")
   end
 
   scenario %(

--- a/features/ping_pong.testfile
+++ b/features/ping_pong.testfile
@@ -51,6 +51,44 @@ scenario = [
       },
       {
         sleep: {
+          time: 0.5
+        }
+      },
+      {
+        send: {
+          data: {
+            command: "pong"
+          }
+        }
+      },
+      {
+        receive: {
+          "data>": {
+            type: "ping"
+          }
+        }
+      },
+      {
+        sleep: {
+          time: 0.5
+        }
+      },
+      {
+        send: {
+          data: {
+            command: "pong"
+          }
+        }
+      },
+      {
+        receive: {
+          "data>": {
+            type: "ping"
+          }
+        }
+      },
+      {
+        sleep: {
           time: 1
         }
       },

--- a/mocks/Broker.go
+++ b/mocks/Broker.go
@@ -70,24 +70,6 @@ func (_m *Broker) FinishPresence(sid string) error {
 	return r0
 }
 
-// FinishSession provides a mock function with given fields: sid
-func (_m *Broker) FinishSession(sid string) error {
-	ret := _m.Called(sid)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FinishSession")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(sid)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // HandleBroadcast provides a mock function with given fields: msg
 func (_m *Broker) HandleBroadcast(msg *common.StreamMessage) {
 	_m.Called(msg)
@@ -334,6 +316,24 @@ func (_m *Broker) Subscribe(stream string) string {
 		r0 = rf(stream)
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// TouchSession provides a mock function with given fields: sid
+func (_m *Broker) TouchSession(sid string) error {
+	ret := _m.Called(sid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TouchSession")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(sid)
+	} else {
+		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/mocks/Broker.go
+++ b/mocks/Broker.go
@@ -52,24 +52,6 @@ func (_m *Broker) CommitSession(sid string, session broker.Cacheable) error {
 	return r0
 }
 
-// FinishPresence provides a mock function with given fields: sid
-func (_m *Broker) FinishPresence(sid string) error {
-	ret := _m.Called(sid)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FinishPresence")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(sid)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // HandleBroadcast provides a mock function with given fields: msg
 func (_m *Broker) HandleBroadcast(msg *common.StreamMessage) {
 	_m.Called(msg)
@@ -316,6 +298,24 @@ func (_m *Broker) Subscribe(stream string) string {
 		r0 = rf(stream)
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// TouchPresence provides a mock function with given fields: sid
+func (_m *Broker) TouchPresence(sid string) error {
+	ret := _m.Called(sid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TouchPresence")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(sid)
+	} else {
+		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/node/node.go
+++ b/node/node.go
@@ -803,7 +803,7 @@ func (n *Node) ExecuteRemoteCommand(msg *common.RemoteCommandMessage) {
 // Disconnect adds session to disconnector queue and unregister session from hub
 func (n *Node) Disconnect(s *Session) error {
 	if s.IsResumeable() {
-		n.broker.FinishSession(s.GetID()) // nolint:errcheck
+		n.broker.TouchSession(s.GetID()) // nolint:errcheck
 	}
 
 	n.broker.FinishPresence(s.GetID()) // nolint:errcheck

--- a/node/node.go
+++ b/node/node.go
@@ -806,7 +806,7 @@ func (n *Node) Disconnect(s *Session) error {
 		n.broker.TouchSession(s.GetID()) // nolint:errcheck
 	}
 
-	n.broker.FinishPresence(s.GetID()) // nolint:errcheck
+	n.broker.TouchPresence(s.GetID()) // nolint:errcheck
 
 	if n.IsShuttingDown() {
 		// Make sure session is removed from hub, so we don't try to send

--- a/node/node_mocks_test.go
+++ b/node/node_mocks_test.go
@@ -29,7 +29,8 @@ func NewMockNode() *Node {
 func NewMockSession(uid string, node *Node, opts ...SessionOption) *Session {
 	session := Session{
 		executor:      node,
-		closed:        true,
+		broker:        node.broker,
+		closed:        false,
 		uid:           uid,
 		Log:           slog.With("sid", uid),
 		subscriptions: NewSubscriptionState(),

--- a/node/node_mocks_test.go
+++ b/node/node_mocks_test.go
@@ -37,6 +37,7 @@ func NewMockSession(uid string, node *Node, opts ...SessionOption) *Session {
 		sendCh:        make(chan *ws.SentFrame, 256),
 		encoder:       encoders.JSON{},
 		metrics:       metrics.NoopMetrics{},
+		timers:        &SessionTimers{},
 	}
 
 	session.SetIdentifiers(uid)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/anycable/anycable-go/common"
 	"github.com/anycable/anycable-go/encoders"
@@ -744,7 +745,7 @@ func TestRestoreSession(t *testing.T) {
 	go node.hub.Run()
 	defer node.hub.Shutdown()
 
-	prev_session := NewMockSession("114", node, WithResumable(true))
+	prev_session := NewMockSession("114", node, WithKeepaliveIntervals(500*time.Millisecond, 500*time.Millisecond))
 	prev_session.subscriptions.AddChannel("fruits_channel")
 	prev_session.subscriptions.AddChannelStream("fruits_channel", "arancia")
 	prev_session.subscriptions.AddChannelStream("fruits_channel", "limoni")
@@ -764,7 +765,7 @@ func TestRestoreSession(t *testing.T) {
 		On("Subscribe", mock.Anything).
 		Return(func(name string) string { return name })
 
-	session := NewMockSession("214", node, WithResumable(true), WithPrevSID("114"))
+	session := NewMockSession("214", node, WithKeepaliveIntervals(500*time.Millisecond, 500*time.Millisecond), WithPrevSID("114"))
 
 	t.Run("Successful restore via header", func(t *testing.T) {
 		res, err := node.Authenticate(session)

--- a/node/session.go
+++ b/node/session.go
@@ -856,12 +856,12 @@ func (s *Session) handleTimerEvent(ev timerEvent) {
 	case timerEventHandshake:
 		s.maybeDisconnectIdle()
 	case timerEventPresence:
+		s.broker.TouchPresence(s.GetID()) // nolint:errcheck
 		s.schedulePresence()
 		s.timers.Schedule()
 	case timerEventExpire:
-		if err := s.broker.TouchSession(s.GetID()); err != nil {
-			s.scheduleResumeability()
-		}
+		s.broker.TouchSession(s.GetID()) // nolint:errcheck
+		s.scheduleResumeability()
 		s.timers.Schedule()
 	case timerEventPing:
 		s.sendPing()


### PR DESCRIPTION
### What is the purpose of this pull request?

Refactor session internals to use a single timer instead of a timer per feature (handshake, ping, pong, resumeability, presence—we have a lot of them now!).

This also changes the way we maintain broker caches: sessions and presence. Now we _touch_ them periodically, so we don't rely on `Disonnect` anymore (which is not 100% reliable).

This is a prerequisite for distributed (cluster) presence support.

### What changes did you make? (overview)

- [x] Introduced `node.SessionTimers` structure to maintain session timers
- [x] Replaced all session timers with a single SessionTimers instance
- [x] Refactored `broker.FinishSession(sid) -> broker.TouchSession(sid)`
- [x] Refactored `broker.FinishPresence(sid) -> broker.TouchPresence(sid)` 

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation
