### PR TITLE
Fix unsubscribe bug in hub.go

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install bison
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install bison
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix bug when unsubscribing different stream from the same channel ([@amree][])
+
 ## 1.6.0-dev
 
 - Refactor WebSocket message writing to use queues instead of channels to better handle slow clients. ([@palkan][])

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -257,13 +257,20 @@ func (h *Hub) UnsubscribeSessionFromChannel(session HubSession, targetIdentifier
 	sid := session.GetID()
 
 	if sessionInfo, ok := h.sessions[sid]; ok {
+		streamsToRemove := make([][]string, 0)
+
 		for _, streamInfo := range sessionInfo.streams {
 			stream, identifier := streamInfo[0], streamInfo[1]
 
 			if targetIdentifier == identifier {
-				h.gates[index(stream, h.gatesNum)].Unsubscribe(session, stream, identifier)
-				sessionInfo.RemoveStream(stream, identifier)
+				streamsToRemove = append(streamsToRemove, []string{stream, identifier})
 			}
+		}
+
+		for _, streamToRemove := range streamsToRemove {
+			stream, identifier := streamToRemove[0], streamToRemove[1]
+			h.gates[index(stream, h.gatesNum)].Unsubscribe(session, stream, identifier)
+			sessionInfo.RemoveStream(stream, identifier)
 		}
 	}
 


### PR DESCRIPTION
### What is the purpose of this pull request?

Fixed a bug where unsubscribing from a channel would sometimes leave streams in the hub. This was caused by modifying the streams slice while iterating over it, which could cause some streams to be skipped during unsubscription.

### What changes did you make? (overview)

The fix uses a two-step approach:
1. First collect all streams that need to be removed
2. Then remove them in a separate loop

I have also created a POC at https://github.com/amree/anycable-poc

### Is there anything you'd like reviewers to focus on?

None

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated documentation