### PR TITLE
Fix usage description for `ws_max_pending_size` parameter

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -1158,7 +1158,7 @@ func wsCLIFlags(c *config.Config) []cli.Flag {
 
 		&cli.Uint64Flag{
 			Name:        "ws_max_pending_size",
-			Usage:       "Maximum size of the write queue for session before it's considered slow and disconnected (in kB)",
+			Usage:       "Maximum size (in bytes) of the write queue for a session before it's considered slow and disconnected (0 = unlimited)",
 			Value:       c.WS.MaxPendingSize,
 			Destination: &c.WS.MaxPendingSize,
 		},

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -230,7 +230,7 @@ func TestSend__maxPendingSize(t *testing.T) {
 		session.Send(&common.Reply{Type: "message", Message: "test A"})
 		time.Sleep(100 * time.Millisecond)
 
-		// This message stays in the queue, size is 37 bytes (31 boilerplate + 6 message)
+		// This message stays in the queue, size is 37 bytes (31 boilerplate + 6 content)
 		session.Send(&common.Reply{Type: "message", Message: "test B"})
 
 		// This message tests the maxPendingSize check

--- a/node/session_test.go
+++ b/node/session_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"strings"
 	"sync"
 	"testing"
 	"time"


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Fixes #251 

- updates usage description to include correct units, and add that 0 means unlimited
- update tests to reflect actual behavior

For reference, the behavior is enforced [here](https://github.com/anycable/anycable/blob/ff7a1e2b4fa00aae325fad8135e1a713e6a21627/node/session.go#L708).

<!--
  Otherwise, describe the changes:

### What is the purpose of this pull request?

### What changes did you make? (overview)

### Is there anything you'd like reviewers to focus on?

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated documentation

-->
