### PR TITLE
Basic Pusher protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- Add basic Pusher protocol support. ([@palkan][])
+
 - Enable Redis pub/sub if Redis is configured or used by other components. ([@palkan][])
 
 ## 1.6.1 (2025-04-17)

--- a/cli/options.go
+++ b/cli/options.go
@@ -118,6 +118,7 @@ func NewConfigFromCLI(args []string, opts ...cliOption) (*config.Config, error, 
 	flags = append(flags, statsdCLIFlags(&c)...)
 	flags = append(flags, embeddedNatsCLIFlags(&c, &enatsRoutes, &enatsGateways)...)
 	flags = append(flags, sseCLIFlags(&c)...)
+	flags = append(flags, pusherCLIFlags(&c)...)
 	flags = append(flags, miscCLIFlags(&c, &presets)...)
 
 	app := &cli.App{
@@ -460,6 +461,7 @@ const (
 	miscCategoryDescription          = "MISC:"
 	brokerCategoryDescription        = "BROKER:"
 	sseCategoryDescription           = "SERVER-SENT EVENTS:"
+	pusherCategoryDescription        = "PUSHER:"
 
 	envPrefix = "ANYCABLE_"
 )
@@ -1338,6 +1340,17 @@ func signedStreamsCLIFlags(c *config.Config, turboRailsKey *string, cableReadyKe
 			Usage:       "[DEPRECATED] Enable Cable Ready fastlane without stream names signing",
 			Destination: cableReadyCleartext,
 			Hidden:      true,
+		},
+	})
+}
+
+// Pusher flags
+func pusherCLIFlags(c *config.Config) []cli.Flag {
+	return withDefaults(pusherCategoryDescription, []cli.Flag{
+		&cli.StringFlag{
+			Name:        "pusher_app_key",
+			Usage:       "Pusher clients public app key",
+			Destination: &c.Pusher.AppKey,
 		},
 	})
 }

--- a/common/common.go
+++ b/common/common.go
@@ -56,6 +56,7 @@ func IsExtendedActionCableProtocol(protocol string) bool {
 const (
 	WelcomeType    = "welcome"
 	PingType       = "ping"
+	PongType       = "pong"
 	DisconnectType = "disconnect"
 	ConfirmedType  = "confirm_subscription"
 	RejectedType   = "reject_subscription"

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	nconfig "github.com/anycable/anycable-go/nats"
 	"github.com/anycable/anycable-go/node"
 	"github.com/anycable/anycable-go/pubsub"
+	"github.com/anycable/anycable-go/pusher"
 	rconfig "github.com/anycable/anycable-go/redis"
 	"github.com/anycable/anycable-go/rpc"
 	"github.com/anycable/anycable-go/server"
@@ -58,6 +59,7 @@ type Config struct {
 	EmbeddedNats         enats.Config               `toml:"embedded_nats"`
 	SSE                  sse.Config                 `toml:"sse"`
 	Streams              streams.Config             `toml:"streams"`
+	Pusher               pusher.Config              `toml:"pusher"`
 
 	ConfigFilePath string
 }
@@ -90,6 +92,7 @@ func NewConfig() Config {
 		EmbeddedNats:         enats.NewConfig(),
 		SSE:                  sse.NewConfig(),
 		Streams:              streams.NewConfig(),
+		Pusher:               pusher.NewConfig(),
 	}
 
 	return config // nolint:govet
@@ -202,6 +205,9 @@ func (c *Config) ToToml() string {
 
 	result.WriteString("# SSE configuration\n[sse]\n")
 	result.WriteString(c.SSE.ToToml())
+
+	result.WriteString("# Pusher compatibility configuration\n[pusher]\n")
+	result.WriteString(c.Pusher.ToToml())
 
 	result.WriteString("# Redis configuration\n[redis]\n")
 	result.WriteString(c.Redis.ToToml())

--- a/features/pusher.testfile
+++ b/features/pusher.testfile
@@ -1,0 +1,63 @@
+launch :anycable,
+  "./dist/anycable-go --pusher_app_key=my-test-id --public_streams"
+
+wait_tcp 8080
+
+scenario = [
+  {
+    receive: {
+      "data>" => {
+        event: "pusher:connection_established"
+      }
+    }
+  },
+  {
+    send: {
+      data: {
+        event: "pusher:subscribe",
+        data: {
+          channel: "test-pusher-channel",
+          auth: ""
+        }
+      }
+    }
+  },
+  {
+    receive: {
+      "data>" => {
+        event: "pusher_internal:subscription_succeeded"
+      }
+    }
+  },
+  {
+    receive: {
+      "data>" => {
+        event: "test-event",
+        channel: "test-pusher-channel"
+      }
+    }
+  }
+]
+
+TEST_COMMAND = <<~CMD
+  bundle exec wsdirector ws://localhost:8080/app/my-test-id -i #{scenario.to_json}
+CMD
+
+q = Queue.new
+Thread.new do
+  run :wsdirector, TEST_COMMAND
+  q.push(nil)
+end
+
+# Wait a bit to ensure connection and subscription
+sleep 3
+
+broadcast("test-pusher-channel", {event: "test-event", data: {"message":"Hello from Pusha"}})
+
+q.pop
+
+result = stdout(:wsdirector)
+
+unless result.include?("1 clients, 0 failures")
+  fail "Unexpected scenario result:\n#{result}"
+end

--- a/node/node.go
+++ b/node/node.go
@@ -172,6 +172,8 @@ func (n *Node) HandleCommand(s *Session, msg *common.Message) (err error) {
 
 	switch msg.Command {
 	case "pong":
+	case "ping":
+		err = s.handleClientPing(msg)
 	case "subscribe":
 		_, err = n.Subscribe(s, msg)
 	case "unsubscribe":

--- a/node/session.go
+++ b/node/session.go
@@ -898,6 +898,12 @@ func (s *Session) handleNoPong() {
 	s.Disconnect("No Pong", ws.CloseNormalClosure)
 }
 
+func (s *Session) handleClientPing(msg *common.Message) error {
+	s.Log.Debug("ping received")
+	s.Send(&common.Reply{Type: common.PongType})
+	return nil
+}
+
 func (s *Session) handleTimerEvent(ev timerEvent) {
 	if s.IsClosed() {
 		return

--- a/pusher/config.go
+++ b/pusher/config.go
@@ -1,0 +1,34 @@
+package pusher
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Config struct {
+	AppKey string `toml:"app_key"`
+}
+
+// NewConfig returns a new Config
+func NewConfig() Config {
+	return Config{}
+}
+
+func (c *Config) Enabled() bool {
+	return c.AppKey != ""
+}
+
+func (c Config) ToToml() string {
+	var result strings.Builder
+
+	result.WriteString("# The public app key for Pusher clients\n")
+	if c.AppKey != "" {
+		result.WriteString(fmt.Sprintf("app_key = \"%s\"\n", c.AppKey))
+	} else {
+		result.WriteString("# app_key = \"\"\n")
+	}
+
+	result.WriteString("\n")
+
+	return result.String()
+}

--- a/pusher/config_test.go
+++ b/pusher/config_test.go
@@ -1,0 +1,26 @@
+package pusher
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ToToml(t *testing.T) {
+	conf := NewConfig()
+	conf.AppKey = "test-app"
+
+	tomlStr := conf.ToToml()
+
+	assert.Contains(t, tomlStr, "app_key = \"test-app\"")
+
+	// Round-trip test
+	conf2 := Config{}
+
+	_, err := toml.Decode(tomlStr, &conf2)
+	require.NoError(t, err)
+
+	assert.Equal(t, conf, conf2)
+}

--- a/pusher/encoder.go
+++ b/pusher/encoder.go
@@ -1,0 +1,278 @@
+package pusher
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/encoders"
+	"github.com/anycable/anycable-go/utils"
+	"github.com/anycable/anycable-go/ws"
+)
+
+const encoderID = "pusher7"
+
+// See https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol/
+const (
+	// Client sends this message to establish connection
+	ConnectionEstablishedType = "pusher:connection_established"
+	// Client sends this message to subscribe to a channel
+	SubscribeType = "pusher:subscribe"
+	// Server sends this message to confirm subscription
+	SubscriptionSucceededType = "pusher_internal:subscription_succeeded"
+	// Server sends this message when subscription fails
+	SubscriptionErrorType = "pusher_internal:subscription_error"
+	// Client sends this message to unsubscribe from a channel
+	UnsubscribeType = "pusher:unsubscribe"
+	// Server sends this message with channel data
+	EventType = "pusher:event"
+	// Ping/pong for keepalive
+	PingType = "pusher:ping"
+	PongType = "pusher:pong"
+	// Error message
+	ErrorType = "pusher:error"
+)
+
+const PingPayload = "{\"event\":\"pusher:ping\",\"data\":{}}"
+const PongPayload = "{\"event\":\"pusher:pong\"}"
+
+type PusherMessage struct {
+	Event   string      `json:"event"`
+	Data    interface{} `json:"data,omitempty"`
+	Channel string      `json:"channel,omitempty"`
+}
+
+type PusherSubscriptionData struct {
+	Channel     string `json:"channel"`
+	Auth        string `json:"auth,omitempty"`
+	ChannelData string `json:"channel_data,omitempty"`
+}
+
+type PusherSubscriptionEvent struct {
+	Event string                  `json:"event"`
+	Data  *PusherSubscriptionData `json:"data"`
+}
+
+type PusherConnectionData struct {
+	SocketID        string `json:"socket_id"`
+	ActivityTimeout int    `json:"activity_timeout"`
+}
+
+type errorCode = int
+
+const (
+	// reconnect: false
+	errorUnauthorized errorCode = 4009
+	// reconnect: true
+	errorGeneric errorCode = 4200
+)
+
+type PusherErrorData struct {
+	Message string    `json:"message"`
+	Code    errorCode `json:"code"`
+}
+
+func (msg *PusherMessage) DataString() (string, error) {
+	if msg.Data == nil {
+		return "{}", nil
+	}
+
+	if str, ok := msg.Data.(string); ok {
+		return str, nil
+	}
+
+	jsonStr, err := json.Marshal(msg.Data)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonStr), nil
+}
+
+type Encoder struct {
+	ActivityTimeout int
+}
+
+func NewEncoder() *Encoder {
+	return &Encoder{ActivityTimeout: 30}
+}
+
+var _ encoders.Encoder = (*Encoder)(nil)
+
+func (*Encoder) ID() string {
+	return encoderID
+}
+
+func (pusher *Encoder) Encode(msg encoders.EncodedMessage) (*ws.SentFrame, error) {
+	mtype := msg.GetType()
+
+	if mtype == common.PingType {
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: []byte(PingPayload)}, nil
+	}
+
+	if mtype == common.PongType {
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: []byte(PongPayload)}, nil
+	}
+
+	if mtype == common.DisconnectType {
+		dm := msg.(*common.DisconnectMessage)
+
+		errorMsg := PusherErrorData{Message: dm.Reason}
+
+		if dm.Reconnect {
+			errorMsg.Code = errorGeneric
+		} else {
+			errorMsg.Code = errorUnauthorized
+		}
+
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: utils.ToJSON(PusherMessage{Event: ErrorType, Data: errorMsg})}, nil
+	}
+
+	r, ok := msg.(*common.Reply)
+
+	if !ok {
+		return nil, fmt.Errorf("unknown message type: %v", msg)
+	}
+
+	if r.Type == common.ConfirmedType {
+		channel, err := identifierToChannel(r.Identifier)
+		if err != nil {
+			return nil, err
+		}
+
+		pusherMsg := PusherMessage{
+			Event:   SubscriptionSucceededType,
+			Channel: channel,
+			Data:    map[string]interface{}{},
+		}
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: utils.ToJSON(pusherMsg)}, nil
+	}
+
+	if r.Type == common.RejectedType {
+		errorMsg := PusherErrorData{Message: "rejected", Code: errorUnauthorized}
+
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: utils.ToJSON(PusherMessage{Event: ErrorType, Data: errorMsg})}, nil
+	}
+
+	if r.Type == common.WelcomeType {
+		connectionData := PusherConnectionData{
+			SocketID:        r.Sid,
+			ActivityTimeout: pusher.ActivityTimeout,
+		}
+		pusherMsg := PusherMessage{
+			Event: ConnectionEstablishedType,
+			Data:  connectionData,
+		}
+		return &ws.SentFrame{FrameType: ws.TextFrame, Payload: utils.ToJSON(pusherMsg)}, nil
+	}
+
+	channel, err := identifierToChannel(r.Identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	eventName := ""
+	eventData := r.Message
+
+	if m, ok := r.Message.(map[string]interface{}); ok {
+		if event, exists := m["event"]; exists {
+			if eventStr, ok := event.(string); ok {
+				eventName = eventStr
+			}
+		}
+		if data, exists := m["data"]; exists {
+			eventData = data
+		}
+	}
+
+	if eventName == "" {
+		return nil, nil
+	}
+
+	pusherMsg := PusherMessage{
+		Event:   eventName,
+		Channel: channel,
+		Data:    eventData,
+	}
+
+	return &ws.SentFrame{FrameType: ws.TextFrame, Payload: utils.ToJSON(pusherMsg)}, nil
+}
+
+func (pusher *Encoder) EncodeTransmission(raw string) (*ws.SentFrame, error) {
+	msg := common.Reply{}
+
+	if err := json.Unmarshal([]byte(raw), &msg); err != nil {
+		return nil, err
+	}
+
+	return pusher.Encode(&msg)
+}
+
+func (pusher *Encoder) Decode(raw []byte) (*common.Message, error) {
+	pusherMsg := &PusherMessage{}
+
+	if err := json.Unmarshal(raw, pusherMsg); err != nil {
+		return nil, err
+	}
+
+	msg := &common.Message{}
+
+	if pusherMsg.Event == SubscribeType || pusherMsg.Event == UnsubscribeType {
+		subEvent := &PusherSubscriptionEvent{}
+		if err := json.Unmarshal(raw, subEvent); err != nil {
+			return nil, err
+		}
+		msg.Identifier = channelToIdentifier(subEvent.Data.Channel, subEvent.Data.Auth)
+
+		if pusherMsg.Event == SubscribeType {
+			msg.Command = "subscribe"
+		} else {
+			msg.Command = "unsubscribe"
+		}
+
+		if subEvent.Data != nil {
+			msg.Data = subEvent.Data
+		}
+	}
+
+	if pusherMsg.Event == PingType {
+		msg.Command = "ping"
+	}
+
+	if pusherMsg.Event == PongType {
+		msg.Command = "pong"
+	}
+
+	if msg.Command == "" {
+		return nil, fmt.Errorf("unsupported event: %s", pusherMsg.Event)
+	}
+
+	return msg, nil
+}
+
+func identifierToChannel(id string) (string, error) {
+	msg := struct {
+		Channel    string `json:"channel"`
+		StreamName string `json:"stream_name"`
+	}{}
+
+	if err := json.Unmarshal([]byte(id), &msg); err != nil {
+		return "", err
+	}
+
+	// TODO: Add a separate Pusher channel class
+	if msg.Channel != "$pubsub" {
+		return "", fmt.Errorf("invalid channel name: %s", msg.Channel)
+	}
+
+	return msg.StreamName, nil
+}
+
+func channelToIdentifier(channel string, signedChannel string) string {
+	msg := struct {
+		Channel          string `json:"channel"`
+		StreamName       string `json:"stream_name"`
+		SignedStreamName string `json:"signed_stream_name,omitempty"`
+	}{Channel: "$pubsub", StreamName: channel, SignedStreamName: signedChannel}
+
+	return string(utils.ToJSON(msg))
+}

--- a/pusher/encoder_test.go
+++ b/pusher/encoder_test.go
@@ -1,0 +1,251 @@
+package pusher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anycable/anycable-go/common"
+	"github.com/anycable/anycable-go/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const identifier = "{\"channel\":\"$pubsub\",\"stream_name\":\"pucha\"}"
+const privateIdentifier = "{\"channel\":\"$pubsub\",\"stream_name\":\"private-party\",\"signed_stream_name\":\"signed-private-party\"}"
+
+func TestPusherEncode(t *testing.T) {
+	coder := NewEncoder()
+
+	t.Run("Reply with event and data", func(t *testing.T) {
+		message := map[string]interface{}{
+			"event": "custom-event",
+			"data":  "custom-data",
+		}
+		msg := &common.Reply{Identifier: identifier, Message: message}
+
+		expected := "{\"event\":\"custom-event\",\"data\":\"custom-data\",\"channel\":\"pucha\"}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Reply w/o event/data", func(t *testing.T) {
+		msg := &common.Reply{Identifier: identifier, Message: "hello"}
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Nil(t, actual)
+	})
+
+	t.Run("Reply with private channel", func(t *testing.T) {
+		message := map[string]interface{}{
+			"event": "custom-event",
+			"data":  "custom-data",
+		}
+		msg := &common.Reply{Identifier: privateIdentifier, Message: message}
+
+		expected := "{\"event\":\"custom-event\",\"data\":\"custom-data\",\"channel\":\"private-party\"}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Ping", func(t *testing.T) {
+		msg := &common.PingMessage{Type: common.PingType, Message: time.Now().Unix()}
+
+		expected := "{\"event\":\"pusher:ping\",\"data\":{}}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Pong", func(t *testing.T) {
+		msg := &common.Reply{Type: common.PongType}
+
+		expected := "{\"event\":\"pusher:pong\"}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Disconnect with reconnect", func(t *testing.T) {
+		msg := &common.DisconnectMessage{Type: "disconnect", Reason: "server error", Reconnect: true}
+
+		expected := "{\"event\":\"pusher:error\",\"data\":{\"message\":\"server error\",\"code\":4200}}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Disconnect without reconnect", func(t *testing.T) {
+		msg := &common.DisconnectMessage{Type: "disconnect", Reason: "unauthorized", Reconnect: false}
+
+		expected := "{\"event\":\"pusher:error\",\"data\":{\"message\":\"unauthorized\",\"code\":4009}}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Welcome", func(t *testing.T) {
+		msg := &common.Reply{Type: common.WelcomeType, Sid: "lu2007"}
+
+		expected := "{\"event\":\"pusher:connection_established\",\"data\":{\"socket_id\":\"lu2007\",\"activity_timeout\":30}}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Confirmed", func(t *testing.T) {
+		msg := &common.Reply{Type: common.ConfirmedType, Identifier: identifier}
+
+		expected := "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":{},\"channel\":\"pucha\"}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("Rejected", func(t *testing.T) {
+		msg := &common.Reply{Type: common.RejectedType, Identifier: identifier}
+
+		expected := "{\"event\":\"pusher:error\",\"data\":{\"message\":\"rejected\",\"code\":4009}}"
+
+		actual, err := coder.Encode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+}
+
+func TestPusherEncodeTransmission(t *testing.T) {
+	coder := NewEncoder()
+
+	t.Run("welcome", func(t *testing.T) {
+		msg := "{\"type\":\"welcome\",\"sid\":\"lu2007\"}"
+		expected := "{\"event\":\"pusher:connection_established\",\"data\":{\"socket_id\":\"lu2007\",\"activity_timeout\":30}}"
+
+		actual, err := coder.EncodeTransmission(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("confirm_subscription", func(t *testing.T) {
+		msg := utils.ToJSON(common.Reply{Identifier: identifier, Type: "confirm_subscription"})
+		expected := "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":{},\"channel\":\"pucha\"}"
+
+		actual, err := coder.EncodeTransmission(string(msg))
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("reject_subscription", func(t *testing.T) {
+		msg := utils.ToJSON(common.Reply{Identifier: identifier, Type: "reject_subscription"})
+		expected := "{\"event\":\"pusher:error\",\"data\":{\"message\":\"rejected\",\"code\":4009}}"
+
+		actual, err := coder.EncodeTransmission(string(msg))
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("message with event", func(t *testing.T) {
+		message := map[string]interface{}{
+			"event": "user-joined",
+			"data":  map[string]string{"name": "John"},
+		}
+		msg := utils.ToJSON(common.Reply{Identifier: identifier, Message: message})
+		expected := "{\"event\":\"user-joined\",\"data\":{\"name\":\"John\"},\"channel\":\"pucha\"}"
+
+		actual, err := coder.EncodeTransmission(string(msg))
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+}
+
+func TestPusherDecode(t *testing.T) {
+	coder := NewEncoder()
+
+	t.Run("subscribe", func(t *testing.T) {
+		msg := []byte("{\"event\":\"pusher:subscribe\",\"data\":{\"auth\":\"\",\"channel\":\"pucha\"}}")
+
+		actual, err := coder.Decode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, "subscribe", actual.Command)
+		assert.Equal(t, identifier, actual.Identifier)
+
+		data, ok := actual.Data.(*PusherSubscriptionData)
+		assert.True(t, ok)
+		assert.Equal(t, "", data.Auth)
+	})
+
+	t.Run("subscribe to private", func(t *testing.T) {
+		msg := []byte("{\"event\":\"pusher:subscribe\",\"data\":{\"auth\":\"signed-private-party\",\"channel\":\"private-party\"}}")
+
+		actual, err := coder.Decode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, "subscribe", actual.Command)
+		assert.Equal(t, privateIdentifier, actual.Identifier)
+
+		data, ok := actual.Data.(*PusherSubscriptionData)
+		assert.True(t, ok)
+		assert.Equal(t, "signed-private-party", data.Auth)
+	})
+
+	t.Run("unsubscribe", func(t *testing.T) {
+		msg := []byte("{\"event\":\"pusher:unsubscribe\",\"data\":{\"channel\":\"pucha\"}}")
+
+		actual, err := coder.Decode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, "unsubscribe", actual.Command)
+		assert.Equal(t, identifier, actual.Identifier)
+	})
+
+	t.Run("ping", func(t *testing.T) {
+		msg := []byte("{\"event\":\"pusher:ping\",\"data\":{}}")
+
+		actual, err := coder.Decode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ping", actual.Command)
+	})
+
+	t.Run("pong", func(t *testing.T) {
+		msg := []byte("{\"event\":\"pusher:pong\"}")
+
+		actual, err := coder.Decode(msg)
+
+		require.NoError(t, err)
+		assert.Equal(t, "pong", actual.Command)
+	})
+
+	t.Run("custom event", func(t *testing.T) {
+		msg := []byte("{\"event\":\"client-message\",\"data\":{\"channel\":\"test-channel\",\"text\":\"hello\"}}")
+
+		actual, err := coder.Decode(msg)
+
+		assert.Error(t, err)
+		assert.Nil(t, actual)
+	})
+}

--- a/streams/controller.go
+++ b/streams/controller.go
@@ -72,7 +72,7 @@ func (c *Controller) Subscribe(sid string, env *common.SessionEnv, ids string, i
 
 	var stream string
 
-	if request.StreamName != "" {
+	if request.SignedStreamName == "" {
 		stream = request.StreamName
 
 		c.log.With("identifier", identifier).Debug("unsigned", "stream", stream)
@@ -158,15 +158,17 @@ func NewStreamsController(conf *Config, l *slog.Logger) *Controller {
 			return nil, err
 		}
 
-		if !allowPublic && request.StreamName != "" {
+		publicStream := request.StreamName != "" && request.SignedStreamName == ""
+
+		if !allowPublic && publicStream {
 			return nil, errors.New("public streams are not allowed")
 		}
 
-		if whispers || (request.StreamName != "") {
+		if whispers || publicStream {
 			request.whisper = true
 		}
 
-		if presence || (request.StreamName != "") {
+		if presence || publicStream {
 			request.presence = true
 		}
 


### PR DESCRIPTION
### What is the purpose of this pull request?

This PR adds the minimal Pusher protocol support. The primary goal for now is to make AnyCable compatible with Laravel Broadcasting/Echo. So, we support public and private channels. Presence channels support to be added later.

### What changes did you make? (overview)

- [x] Added a new `pusher` package with the configuration and encoder
- [x] Added support for client-side `ping` messages (a server simply responds with a `pong` message for now).

### Is there anything you'd like reviewers to focus on?

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation
