### PR TITLE
Bump go to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/anycable/anycable-go
 
-go 1.25.0
+go 1.24.0
 
-toolchain go1.25.3
+toolchain go1.24.9
 
 require (
 	github.com/FZambia/sentinel v1.1.1


### PR DESCRIPTION
Go 1.23 is no longer supported since Go 1.25 is out per https://go.dev/doc/devel/release#policy. This bumps go to version 1.24 which is supported and closes the following CVEs:

CVE-2025-47912
CVE-2025-58183
CVE-2025-58186
CVE-2025-58187
CVE-2025-58188
CVE-2025-61724

Not sure about the failing tests ... could use a maintainer's support, @palkan 