### PR TITLE
Update go to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anycable/anycable-go
 
 go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.25.5
 
 require (
 	github.com/FZambia/sentinel v1.1.1


### PR DESCRIPTION
Due to https://pkg.go.dev/vuln/GO-2025-4155 go was updated to 1.25.5 (https://go.dev/doc/devel/release#go1.25.0).