### PR TITLE
Add MaxPayload configuration for embedded NATS

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -925,6 +925,12 @@ func embeddedNatsCLIFlags(c *config.Config, routes *string, gateways *string) []
 			Destination: &c.EmbeddedNats.Trace,
 			Hidden:      true,
 		},
+
+		&cli.IntFlag{
+			Name:        "enats_max_payload",
+			Usage:       "Maximum message payload size in bytes (default: 1048576 = 1MB)",
+			Destination: &c.EmbeddedNats.MaxPayload,
+		},
 	})
 }
 

--- a/enats/config.go
+++ b/enats/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	StoreDir         string   `toml:"jetstream_store_dir"`
 	// Seconds to wait for JetStream to become ready (can take a lot of time when connecting to a cluster)
 	JetStreamReadyTimeout int `toml:"jetstream_ready_timeout"`
+	// Maximum message payload size in bytes (default: 1048576 = 1MB)
+	MaxPayload int `toml:"max_payload"`
 }
 
 func (c Config) ToToml() string {
@@ -103,6 +105,13 @@ func (c Config) ToToml() string {
 		result.WriteString(fmt.Sprintf("jetstream_ready_timeout = %d\n", c.JetStreamReadyTimeout))
 	} else {
 		result.WriteString(fmt.Sprintf("# jetstream_ready_timeout = %d\n", c.JetStreamReadyTimeout))
+	}
+
+	result.WriteString("#\n# Maximum message payload size\n#\n")
+	if c.MaxPayload > 0 {
+		result.WriteString(fmt.Sprintf("max_payload = %d\n", c.MaxPayload))
+	} else {
+		result.WriteString("# max_payload = 1048576\n")
 	}
 
 	return result.String()

--- a/enats/config_test.go
+++ b/enats/config_test.go
@@ -24,6 +24,7 @@ func TestConfig_ToToml(t *testing.T) {
 		JetStream:             true,
 		StoreDir:              "/tmp/nats-store",
 		JetStreamReadyTimeout: 30,
+		MaxPayload:            4194304,
 	}
 
 	tomlStr := conf.ToToml()
@@ -42,6 +43,7 @@ func TestConfig_ToToml(t *testing.T) {
 	assert.Contains(t, tomlStr, "jetstream = true")
 	assert.Contains(t, tomlStr, "jetstream_store_dir = \"/tmp/nats-store\"")
 	assert.Contains(t, tomlStr, "jetstream_ready_timeout = 30")
+	assert.Contains(t, tomlStr, "max_payload = 4194304")
 
 	// Round-trip test
 	var conf2 Config
@@ -49,4 +51,15 @@ func TestConfig_ToToml(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, conf, conf2)
+}
+
+func TestConfig_ToToml_DefaultMaxPayload(t *testing.T) {
+	conf := Config{
+		ServiceAddr: "localhost:4222",
+	}
+
+	tomlStr := conf.ToToml()
+
+	// When MaxPayload is 0 (default), it should be commented out
+	assert.Contains(t, tomlStr, "# max_payload = 1048576")
 }

--- a/enats/enats.go
+++ b/enats/enats.go
@@ -132,6 +132,7 @@ func (s *Service) Start() error {
 		Routes:     routes,
 		NoSigs:     true,
 		JetStream:  s.config.JetStream,
+		MaxPayload: int32(s.config.MaxPayload),
 	}
 
 	if s.config.StoreDir != "" {


### PR DESCRIPTION
## Summary

Add the ability to configure the maximum message payload size for the embedded NATS server.

**Configuration options:**
- CLI flag: `--enats_max_payload`
- Environment variable: `ANYCABLE_ENATS_MAX_PAYLOAD`
- TOML config: `max_payload`

## Background

We've been using AnyCable since 2017 and are Pro subscribers. We're currently working on simplifying our infrastructure, and this is the last piece in our end-user-facing application that still requires Redis. Being able to use embedded NATS with larger payloads would allow us to completely eliminate Redis from our stack.

## Problem

The default NATS max payload is 1MB, which can be insufficient for applications broadcasting large JSON payloads. Our live result application broadcasts schedule data for sporting events where large events can have 700+ classes, resulting in JSON payloads up to 2.6MB.

Currently, the only workaround is to use an external NATS server with the `--max_payload` flag, which defeats the simplicity benefit of embedded NATS.

## Solution

This PR exposes the NATS server's `MaxPayload` option through AnyCable's configuration system, allowing users to increase the limit when using embedded NATS.

**Example usage:**
```bash
anycable-go --enats_max_payload 4194304
# or
ANYCABLE_ENATS_MAX_PAYLOAD=4194304 anycable-go
```

## Changes

- Added `MaxPayload` field to `enats.Config` struct
- Added TOML serialization support for `max_payload`
- Added `--enats_max_payload` CLI flag
- Applied `MaxPayload` to NATS server options
- Added tests for configuration serialization

## Test plan

- [x] Unit tests pass (`go test ./enats/...`)
- [x] Config round-trip test verifies TOML serialization
- [x] Default value (0) correctly defers to NATS server default (1MB)
- [x] Build succeeds (`go build ./...`)