### PR TITLE
Update Go toolchain version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anycable/anycable-go
 
 go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.6
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
### What is the purpose of this pull request?

go1.25.6 (released 2026-01-15) includes security fixes to the go command, and the archive/zip, crypto/tls, and net/url packages, as well as bug fixes to the compiler, the runtime, and the crypto/tls, errors, and os packages. See the [Go 1.25.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.6+label%3ACherryPickApproved) on our issue tracker for details.

### What changes did you make? (overview)

Bumped Go from 1.25.5 to 1.25.6