### PR TITLE
Add dependabot and pin actions to hash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,8 +23,8 @@ jobs:
         ports: ["6379:6379"]
         options: --health-cmd="redis-cli ping" --health-interval 1s --health-timeout 3s --health-retries 30
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
     - name: Install system deps
@@ -40,7 +40,7 @@ jobs:
         # Use <3.0 since go-mruby's Rakefile has some problems with keyword arguments compatibility
         ruby-version: 2.7
         bundler-cache: true
-    - uses: actions/cache@v3
+    - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: vendor
         key: vendor-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: golangci-lint

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -13,12 +13,12 @@ jobs:
       GOFLAGS: "-mod=vendor"
       ANYCABLE_TELEMETRY_TOKEN: ${{ secrets.ANYCABLE_TELEMETRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install system deps
         run: |
           sudo apt-get update
           sudo apt-get install bison
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}
@@ -32,7 +32,7 @@ jobs:
           bundler-cache: true
       - name: Build mruby
         run: bash -c '(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make libmruby.a)'
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Set VERSION (if any)
@@ -79,17 +79,17 @@ jobs:
       GOFLAGS: "-mod=vendor"
       ANYCABLE_TELEMETRY_TOKEN: ${{ secrets.ANYCABLE_TELEMETRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install system deps
         run: |
           brew install bison
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             vendor-
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - run: go mod vendor

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -13,12 +13,12 @@ jobs:
       GOFLAGS: "-mod=vendor"
       ANYCABLE_TELEMETRY_TOKEN: ${{ secrets.ANYCABLE_TELEMETRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install system deps
         run: |
           sudo apt-get update
           sudo apt-get install bison
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}
@@ -32,7 +32,7 @@ jobs:
           bundler-cache: true
       - name: Build mruby
         run: bash -c '(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make libmruby.a)'
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Set VERSION (if any)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
         ports: ["6379:6379"]
         options: --health-cmd="redis-cli ping" --health-interval 1s --health-timeout 3s --health-retries 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install system deps
         run: |
           sudo apt-get update
           sudo apt-get install bison
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}
@@ -40,7 +40,7 @@ jobs:
           bundler-cache: true
       - name: Build mruby
         run: bash -c '(cd vendor/github.com/mitchellh/go-mruby && MRUBY_CONFIG=../../../../../../etc/build_config.rb make libmruby.a)'
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Run tests
@@ -50,7 +50,7 @@ jobs:
           make build
       - name: Upload linux build
         if: (github.ref == 'refs/head/master' || contains(github.event.pull_request.body, '[Build]'))
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: anycable-go-Linux-x86_64
           path: dist/anycable-go
@@ -63,14 +63,14 @@ jobs:
       GOFLAGS: "-mod=vendor"
       COVERAGE: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Install system deps
         run: |
           brew install bison
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}
@@ -91,7 +91,7 @@ jobs:
           make build
       - name: Upload MacOS build
         if: (github.ref == 'refs/head/master' || contains(github.event.pull_request.body, '[Build]'))
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: anycable-go-Darwin-x86_64
           path: dist/anycable-go
@@ -134,8 +134,8 @@ jobs:
         image: nats:alpine
         ports: ["4222:4222"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
       - name: Install system deps
@@ -154,7 +154,7 @@ jobs:
           # Use <3.0 since go-mruby's Rakefile has some problems with keyword arguments compatibility
           ruby-version: 2.7
           bundler-cache: true
-      - uses: actions/cache@v4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: vendor
           key: vendor-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
### What is the purpose of this pull request?

Add dependabot for `gomod` and `github-actions`. Pin github actions to sha hash to prevent supply chain attacks. See [this writeup](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide) and know that this is real and recently bit [Trivy](https://www.wiz.io/blog/trivy-compromised-teampcp-supply-chain-attack) such that anyone who didn't have their actions pinned could have been affected.

The maintenance burden should be zero since I added dependabot which should update the full SHA hash when new actions are released.