### PR TITLE
Update AWS ECS and Heroku ulimit in OS tuning docs

### DIFF
--- a/docs/os_tuning.md
+++ b/docs/os_tuning.md
@@ -20,7 +20,7 @@ Changing this limit depends on the OS and the way you deploy the server (e.g., f
 
 ### Heroku
 
-Heroku sets the open files limit to 10k, and it's not possible to change it. See more [here](../deployment/heroku.md).
+Heroku sets the open files limit to 10k, and it's not possible to change it. Larger sized dynos (Performance-M +) have an open file limit of 1048576. See more [here](../deployment/heroku.md).
 
 ### AWS ECS
 

--- a/docs/os_tuning.md
+++ b/docs/os_tuning.md
@@ -20,17 +20,18 @@ Changing this limit depends on the OS and the way you deploy the server (e.g., f
 
 ### Heroku
 
-Heroku sets the open files limit to 10k, and it's not possible to change it. Larger sized dynos (Performance-M +) have an open file limit of 1048576. See more [here](../deployment/heroku.md).
+Heroku sets the open files limit to 10k, and it's not possible to change it. Larger sized dynos have an open file limit of ~1M. See more [here](../deployment/heroku.md).
 
 ### AWS ECS
 
-ECS has a default limit of 1024 open files. Make sure you configured [the `ulimit` setting](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html) in your task definition. For example:
+On Fargate, the default soft and hard limit is 65,535 open files. The EC2 launch type's default `ulimit` value will depend upon your host OS configuration, but can still be configured in the task definition. Make sure you configure [the `ulimit` setting](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Ulimit.html) in your task definition. For example:
 
 ```yml
 HardLimit: 1048576
 Name: nofile
 SoftLimit: 1048576
 ```
+
 
 ## TCP keepalive
 


### PR DESCRIPTION
### Description
Updated the OS Tuning docs with the following changes:
-  AWS ECS section now reflects current Fargate `ulimit` defaults of `65535` soft/hard (from `1024` previously)
- Heroku section now specifies that larger dyno sizes have a higher limit of ~1M open files

### Reasoning/Context
I was tasked over the past few months to deploy AnyCable Pro on Fargate, and found this `ulimit` mismatch in my final tuning pass of the deployed service. It seems around **June 2024** AWS upped the open file limit to `65535` from `1024` - since I was about to manually pass those values in, I felt it would be helpful to update the OS tuning docs.

### Sources:
- [ECS Fargate task definition parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters_fargate.html)
- [ECS EC2 task definition parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters_ec2.html)
- [Heroku FAQ regarding file descriptor limits](https://help.heroku.com/WEJQH08E/is-is-possible-to-increase-the-file-descriptor-ulimit-limit#:~:text=Resolution.%20Unfortunately%2C%20there%20isn't%20a%20way%20to,upon%20the%20size%20of%20the%20dyno%20and)
