### PR TITLE
fix(sse): split multi-line payloads across data: fields

### DIFF
--- a/sse/encoder.go
+++ b/sse/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/anycable/anycable-go/common"
 	"github.com/anycable/anycable-go/encoders"
@@ -51,9 +52,9 @@ func (e *Encoder) Encode(msg encoders.EncodedMessage) (*ws.SentFrame, error) {
 		} else {
 			data = string(utils.ToJSON(reply.Message))
 		}
-		payload = "data: " + data
+		payload = encodeSSEData(data)
 	} else {
-		payload = "data: " + string(b)
+		payload = encodeSSEData(string(b))
 	}
 
 	if msgType != "" {
@@ -78,6 +79,24 @@ func (e *Encoder) Encode(msg encoders.EncodedMessage) (*ws.SentFrame, error) {
 	}
 
 	return &ws.SentFrame{FrameType: ws.TextFrame, Payload: []byte(payload)}, nil
+}
+
+// sseDataLineBreak rewrites every line terminator into a new `data:` field
+// boundary. Order matters: CRLF is matched before lone CR/LF.
+var sseDataLineBreak = strings.NewReplacer("\r\n", "\ndata: ", "\r", "\ndata: ", "\n", "\ndata: ")
+
+// encodeSSEData formats a payload as one or more SSE `data:` fields.
+//
+// Per the SSE specification, an event's data is encoded as one `data:` field
+// per line; the client (e.g. EventSource) rejoins the fields with "\n". A raw
+// line terminator after a single `data:` prefix would truncate the payload at
+// the first line break, because the following lines are parsed as fields other
+// than `data` and ignored. LF, CR and CRLF are all line terminators per the
+// spec, so all three are normalized. This matters for unwrapped payloads, which
+// may be arbitrary multi-line strings; JSON-encoded payloads are unaffected
+// (their newlines are already escaped).
+func encodeSSEData(payload string) string {
+	return "data: " + sseDataLineBreak.Replace(payload)
 }
 
 func (e Encoder) EncodeTransmission(raw string) (*ws.SentFrame, error) {

--- a/sse/encoder_test.go
+++ b/sse/encoder_test.go
@@ -43,6 +43,52 @@ func TestEncoder_Encode(t *testing.T) {
 		assert.Equal(t, expected, string(actual.Payload))
 	})
 
+	t.Run("without type + unwrap data + multiline payload", func(t *testing.T) {
+		getCoder := Encoder{UnwrapData: true}
+		// Multi-line payloads (e.g. Turbo Stream HTML) must be split across
+		// multiple `data:` fields, otherwise EventSource truncates at the first
+		// newline. The client rejoins the fields with "\n".
+		msg := &common.Reply{Identifier: "test_channel", Message: "<turbo-stream>\n<template>\nhi\n</template>\n</turbo-stream>"}
+		expected := "data: <turbo-stream>\n" +
+			"data: <template>\n" +
+			"data: hi\n" +
+			"data: </template>\n" +
+			"data: </turbo-stream>"
+
+		actual, err := getCoder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("without type + unwrap data + CRLF and CR terminators", func(t *testing.T) {
+		getCoder := Encoder{UnwrapData: true}
+		// LF, CR and CRLF are all SSE line terminators and must each start a
+		// new data: field.
+		msg := &common.Reply{Identifier: "test_channel", Message: "a\r\nb\rc\nd"}
+		expected := "data: a\n" +
+			"data: b\n" +
+			"data: c\n" +
+			"data: d"
+
+		actual, err := getCoder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
+	t.Run("with type + multiline payload preserves event and id", func(t *testing.T) {
+		msg := &common.Reply{Type: "test", Identifier: "test_channel", Message: "a\nb", StreamID: "stream-test", Epoch: "bc320", Offset: 321}
+		expected := "event: test\n" +
+			`data: {"type":"test","identifier":"test_channel","message":"a\nb","stream_id":"stream-test","epoch":"bc320","offset":321}` + "\n" +
+			"id: 321/bc320/stream-test"
+
+		actual, err := coder.Encode(msg)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual.Payload))
+	})
+
 	t.Run("with type", func(t *testing.T) {
 		rawCoder := Encoder{RawData: true}
 		msg := &common.Reply{Type: "test", Identifier: "test_channel", Message: "hello"}


### PR DESCRIPTION
### What is the purpose of this pull request?

Fix multi-line payloads being truncated when delivered over SSE.

The SSE encoder writes the payload after a single `data:` prefix. Per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), a multi-line `data` value must be split into one `data:` field per line (the client rejoins them with `\n`). A raw line terminator after a single `data:` ends the field, and the following lines are parsed as other fields — so the payload is truncated at the first newline.

This affects unwrapped GET/EventSource connections, where `data` is the raw message: any multi-line string is silently cut to its first line at the client. Single-line payloads (e.g. `"hello"`) hide the issue, which is why the existing examples work.

The fix normalizes every line terminator (LF, CR, CRLF — all three per the spec) into a new `data:` field boundary in `sse/encoder.go`. JSON-encoded branches are a no-op, since their newlines are already escaped. `sse/encoder_test.go` adds tests for a multi-line unwrapped payload, mixed CR/LF/CRLF terminators, and an event with an escaped-newline message plus offset/id.

### Repro (before this PR)

Subscribe over SSE and broadcast any multi-line payload. The raw stream carries the whole value after a single `data:`:

```
data: line one
line two
line three
```

A browser `EventSource` reads `event.data` as only `line one` — the following lines lack the `data:` field name and are ignored — so the consumer never sees the full payload. With this PR each line gets its own field:

```
data: line one
data: line two
data: line three
```

so `event.data` is `line one\nline two\nline three`. This is the canonical way to encode multi-line data in SSE.

### Possible side benefit: protocol field injection

> The original goal of this PR is the truncation bug above; this is a possible bonus, not the motivation.

Because the payload was written without a per-line `data:` prefix, a payload line that *looks* like another SSE field was parsed as that field by the client. Since broadcast content is often application/user-controlled (e.g. Turbo Stream HTML), a payload line such as `retry: 10` or `id: ...` lands in field-name position. I observed this with a real `EventSource` against the current code:

- A payload containing `retry: 8000` set the client's reconnection time to 8000ms (vs the 3000ms default) — so an attacker-controlled payload could drive a reconnect storm (`retry: 10`) or suppress reconnection.
- A payload containing `id: ...` set the client's `lastEventId`; with a value in the `offset/epoch/stream` format the client replays it as `Last-Event-ID` on reconnect, which the server then parses as a history request.

After this PR every payload line is prefixed with `data:`, so nothing from the payload reaches field-name position and both behaviors go away. This is a side effect of the fix, not something I set out to address — flagging it in case it's worth a closer look.
