### PR TITLE
Fix metrics_log/StatsD silently disabled when a dedicated metrics HTTP server is configured

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -123,19 +123,39 @@ func (m *Metrics) RegisterWriter(w IntervalWriter) {
 
 // Run periodically updates counters delta (and logs metrics if necessary)
 func (m *Metrics) Run() error {
+	serverErr := make(chan error, 1)
+
 	if m.server != nil {
 		m.log.Info(fmt.Sprintf("Serve metrics at %s%s", m.server.Address(), m.httpPath))
 
-		if err := m.server.StartAndAnnounce("Metrics server"); err != nil {
-			if !m.server.Stopped() {
-				return fmt.Errorf("metrics HTTP server at %s stopped: %v", m.server.Address(), err)
+		// Serve blocks until shutdown, so the server must run in its own
+		// goroutine — otherwise the rotation loop below is never reached and
+		// the interval writers (metrics logging, StatsD) are silently disabled
+		// whenever a dedicated (not yet running) metrics server is configured.
+		go func() {
+			if err := m.server.StartAndAnnounce("Metrics server"); err != nil {
+				if !m.server.Stopped() {
+					serverErr <- fmt.Errorf("metrics HTTP server at %s stopped: %v", m.server.Address(), err)
+				}
 			}
-		}
+		}()
 	}
 
 	if len(m.writers) == 0 {
 		m.log.Debug("no metrics writers, disabling metrics rotation")
-		return nil
+
+		if m.server == nil {
+			return nil
+		}
+
+		// No rotation to drive, but keep surfacing a dedicated-server failure
+		// the way the blocking version did.
+		select {
+		case err := <-serverErr:
+			return err
+		case <-m.shutdownCh:
+			return nil
+		}
 	}
 
 	if m.rotateInterval == 0 {
@@ -150,6 +170,8 @@ func (m *Metrics) Run() error {
 
 	for {
 		select {
+		case err := <-serverErr:
+			return err
 		case <-m.shutdownCh:
 			return nil
 		case <-time.After(m.rotateInterval):

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,10 +1,14 @@
 package metrics
 
 import (
+	"context"
 	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/anycable/anycable-go/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetricsSnapshot(t *testing.T) {
@@ -84,4 +88,43 @@ func TestMetrics_EachCounter(t *testing.T) {
 			}
 		}
 	})
+}
+
+type signalWriter struct {
+	ran chan struct{}
+}
+
+func (w *signalWriter) Run(interval int) error {
+	close(w.ran)
+	return nil
+}
+
+func (w *signalWriter) Write(m *Metrics) error { return nil }
+
+func (w *signalWriter) Stop() {}
+
+// Regression test: with a dedicated metrics HTTP server configured, Run() must
+// still reach the interval writers / rotation loop. Previously the server was
+// started synchronously and its blocking Serve starved the rotation loop, so
+// metrics logging and StatsD were silently disabled.
+func TestRunWithDedicatedServerStartsRotation(t *testing.T) {
+	w := &signalWriter{ran: make(chan struct{})}
+	m := NewMetrics([]IntervalWriter{w}, 1, slog.Default())
+
+	srv, err := server.NewServer("127.0.0.1", "0", server.SSL, 0)
+	require.NoError(t, err)
+	m.server = srv
+
+	done := make(chan error, 1)
+	go func() { done <- m.Run() }()
+	defer m.Shutdown(context.Background()) // nolint:errcheck
+
+	select {
+	case <-w.ran:
+		// rotation started — the server did not block Run
+	case err := <-done:
+		t.Fatalf("Run returned before starting the interval writers: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("rotation loop never started: the metrics server start is blocking Run")
+	}
 }


### PR DESCRIPTION
## What

`Metrics.Run()` starts the metrics HTTP server synchronously, and
`HTTPServer.Start()` ends in a blocking `http.Server.Serve()`. When the metrics
endpoint is served by a dedicated server (own `metrics_host`/`metrics_port`,
i.e. a server that isn't already running), `Run()` blocks right there and never
reaches the rotation loop — interval snapshots are never taken, so the interval
writers (`metrics_log`, StatsD) are silently disabled. The Prometheus endpoint
is unaffected (its handler reads the cumulative counters directly), which makes
the breakage easy to miss.

When the metrics endpoint shares an already-running server, `StartAndAnnounce`
returns immediately and everything works — which is probably why this hasn't
been noticed.

## Repro

Run anycable-go with `--metrics_log --metrics_http=/metrics --metrics_port=8081`:
the `Serve metrics at ...` banner appears and `/metrics` responds, but the
periodic metrics lines never show up in the log (the printer's startup
`log metrics` line doesn't either). Drop the `--metrics_http*` flags and the
15-second lines come back.

Observed on 1.6.7 and 1.6.14.

## Fix

Start the dedicated server in a goroutine — the same pattern
`Runner.startWSServer` uses — and surface a dedicated-server failure via the
rotation loop's `select`, preserving `Run()`'s error semantics (including the
no-writers case).

Adds a regression test: with a dedicated server configured, `Run()` must reach
the interval writers.
