### PR TITLE
Bump copyright year to 2026

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016-2023 Vladimir Dementyev
+Copyright 2016-2026 Vladimir Dementyev
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Refresh the copyright end-year to 2026 (repo is still actively maintained).