### PR TITLE
Preserve Redis database number in Sentinel mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## master
+
+- Honor the Redis database number from the URL in Sentinel mode. ([@paderinandrey][])
+
 ## 1.6.14 (2026-06-26)
 
 - Minor perf improvements in broadcasting hub.
@@ -520,3 +524,4 @@ See [Changelog](https://github.com/anycable/anycable-go/blob/0-6-stable/CHANGELO
 [@rafaelrubbioli]: https://github.com/rafaelrubbioli
 [@gzigzigzeo]: https://github.com/gzigzigzeo
 [@ardecvz]: https://github.com/ardecvz
+[@paderinandrey]: https://github.com/paderinandrey

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,10 @@ You can specify on which port to receive broadcasting requests (NOTE: it could b
 
 Redis URL to connect to (default: `"redis://localhost:6379/5"`). Used by the corresponding pub/sub, broadcasting, and broker adapters.
 
+**--redis_sentinels** (`ANYCABLE_REDIS_SENTINELS`)
+
+Comma-separated list of Redis Sentinel addresses (e.g., `sentinel-1:26379,sentinel-2:26379`) enabling Sentinel mode. When set, the host part of `--redis_url` is treated as the Sentinel master name, and the database number from the URL is respected (e.g., `redis://mymaster/5` connects to db `5` of the resolved master). Sentinel credentials may be provided inline: `:password@host:port`.
+
 **--redis_channel** (`ANYCABLE_REDIS_CHANNEL`)
 
 Redis channel for broadcasting (default: `"__anycable__"`). When using the `redisx` adapter, it's used as a name of the Redis stream.

--- a/redis/config.go
+++ b/redis/config.go
@@ -183,6 +183,9 @@ func (config *RedisConfig) parseSentinels() (*rueidis.ClientOption, error) {
 	if masterErr == nil {
 		options.Username = masterOpts.Username
 		options.Password = masterOpts.Password
+		if redisURLHasDB(config.URL) {
+			options.SelectDB = masterOpts.SelectDB
+		}
 	} else {
 		options.Username = ""
 		options.Password = ""
@@ -273,6 +276,17 @@ func parseRedisURL(url string) (options *rueidis.ClientOption, err error) {
 	}
 
 	return options, nil
+}
+
+func redisURLHasDB(rawURL string) bool {
+	urls := strings.Split(rawURL, ",")
+	parsedURL, err := url.Parse(ensureRedisScheme(chompTrailingSlashHostname(urls[0])))
+
+	if err != nil {
+		return false
+	}
+
+	return parsedURL.Path != "" && parsedURL.Path != "/"
 }
 
 // TODO: upstream this change to `rueidis` URL parsing

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -355,6 +355,18 @@ func TestSentinelNoAuth(t *testing.T) {
 	assert.Equal(t, "", options.Sentinel.Password)
 	assert.Equal(t, "", options.Username)
 	assert.Equal(t, "", options.Password)
+	assert.Equal(t, 0, options.SelectDB)
+}
+
+func TestSentinelConfigPreservesRedisDB(t *testing.T) {
+	config := NewRedisConfig()
+	config.URL = "redis://mymaster/5"
+	config.Sentinels = "localhost:26379"
+
+	options, err := config.ToRueidisOptions()
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, options.SelectDB)
 }
 
 func TestSentinelAuthOnly(t *testing.T) {


### PR DESCRIPTION
### What is the purpose of this pull request?

When Redis Sentinel mode is enabled, anycable-go ignores the database number specified in `ANYCABLE_REDIS_URL` and always connects to Redis database `0`.

For example:
```sh
ANYCABLE_REDIS_URL=redis://mymaster/5
ANYCABLE_REDIS_SENTINELS=sentinel-1:26379,sentinel-2:26379,sentinel-3:26379
```
Expected behavior:

* AnyCable-Go connects to database 5.

Actual behavior:

* AnyCable-Go connects to database 0.

The database number from `ANYCABLE_REDIS_URL` is respected in non-Sentinel mode, but ignored when Sentinel mode is used.

##  Why it matters

This makes Sentinel and non-Sentinel configurations behave differently despite using the same Redis URL.

In Sentinel mode, `RedisConfig.parseSentinels()` builds Redis connection options from Sentinel addresses and restores authentication settings from the master URL, but does not restore the database number. As a result, `SelectDB` always falls back to the default value (0).

Applications that rely on a non-default Redis database for AnyCable may observe unexpected behavior, since the configured database is silently ignored.

##  What this PR does

This PR preserves the database number specified in `ANYCABLE_REDIS_URL` when Sentinel mode is enabled.

A new helper, `redisURLHasDB()`, is used to distinguish between an explicitly configured database and the default Redis behavior:
* For `redis://mymaster/5`, `SelectDB` is set to `5`
* For `redis://mymaster`, `SelectDB` remains `0` (unchanged)

This change makes Sentinel mode consistent with non-Sentinel mode while remaining fully backward compatible for existing configurations that do not specify a database number.

### Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated documentation